### PR TITLE
feat: proteksi edit & hapus peserta (BR-14)

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -65,7 +65,11 @@ class ParticipantController extends Controller
     {
         $this->authorizeParticipant($participant);
 
-        return view('participants.show', compact('participant'));
+        $canDelete = $this->participantService->canDelete($participant);
+        $deleteReason = $this->participantService->getDeleteReason($participant);
+        $hasActiveRegistration = $participant->registrations()->whereNull('deleted_at')->exists();
+
+        return view('participants.show', compact('participant', 'canDelete', 'deleteReason', 'hasActiveRegistration'));
     }
 
     public function edit(Participant $participant)
@@ -75,7 +79,12 @@ class ParticipantController extends Controller
         $lockedFields = $this->participantService->getLockedFields($participant);
         $canDelete = $this->participantService->canDelete($participant);
 
-        return view('participants.edit', compact('participant', 'lockedFields', 'canDelete'));
+        $lockReasons = [];
+        foreach ($lockedFields as $field) {
+            $lockReasons[$field] = $this->participantService->getLockReason($participant, $field);
+        }
+
+        return view('participants.edit', compact('participant', 'lockedFields', 'canDelete', 'lockReasons'));
     }
 
     public function update(UpdateParticipantRequest $request, Participant $participant)
@@ -85,8 +94,12 @@ class ParticipantController extends Controller
         $validated = $request->validated();
         $lockedFields = $this->participantService->getLockedFields($participant);
 
+        $skippedFields = [];
         foreach ($lockedFields as $field) {
-            unset($validated[$field]);
+            if (array_key_exists($field, $validated)) {
+                $skippedFields[] = $field;
+                unset($validated[$field]);
+            }
         }
 
         if ($request->hasFile('photo')) {
@@ -109,7 +122,12 @@ class ParticipantController extends Controller
 
         $participant->update($validated);
 
-        return redirect()->route('participants.index')->with('success', 'Data peserta berhasil diperbarui.');
+        $message = 'Data peserta berhasil diperbarui.';
+        if (count($skippedFields) > 0) {
+            $message .= ' (' . count($skippedFields) . ' field terkunci dilewati)';
+        }
+
+        return redirect()->route('participants.index')->with('success', $message);
     }
 
     public function destroy(Participant $participant)
@@ -118,9 +136,7 @@ class ParticipantController extends Controller
 
         if (!$this->participantService->canDelete($participant)) {
             return back()->withErrors([
-                'delete' => $participant->is_verified
-                    ? 'Peserta yang sudah terverifikasi tidak dapat dihapus.'
-                    : 'Peserta memiliki registrasi aktif dan tidak dapat dihapus.',
+                'delete' => $this->participantService->getDeleteReason($participant),
             ]);
         }
 

--- a/app/Http/Requests/Participant/UpdateParticipantRequest.php
+++ b/app/Http/Requests/Participant/UpdateParticipantRequest.php
@@ -3,15 +3,18 @@
 namespace App\Http\Requests\Participant;
 
 use App\Models\Participant;
+use App\Services\ParticipantService;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
 
 class UpdateParticipantRequest extends FormRequest
 {
     private ?Participant $participant;
 
-    public function __construct()
-    {
-        $this->participant = $this->route('participant');
+    public function __construct(
+        private ParticipantService $participantService
+    ) {
+        parent::__construct();
     }
 
     public function authorize(): bool
@@ -34,6 +37,37 @@ class UpdateParticipantRequest extends FormRequest
             'photo' => 'nullable|image|max:2048',
             'document' => ['nullable', 'file', 'mimes:jpg,jpeg,png,pdf', 'max:5120'],
         ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            $participant = $this->route('participant');
+
+            if (!$participant) {
+                return;
+            }
+
+            $lockedFields = $this->participantService->getLockedFields($participant);
+
+            foreach ($lockedFields as $field) {
+                $inputValue = $validator->getValue($field);
+                $dbValue = $participant->$field;
+
+                if ($field === 'gender') {
+                    $dbValue = $participant->gender?->value;
+                } elseif ($field === 'birth_date') {
+                    $dbValue = $participant->birth_date?->format('Y-m-d');
+                } elseif ($field === 'type') {
+                    $dbValue = $participant->type?->value;
+                }
+
+                if ((string) $inputValue !== (string) $dbValue) {
+                    $reason = $this->participantService->getLockReason($participant, $field);
+                    $validator->errors()->add($field, "Field {$field} tidak dapat diubah: {$reason}");
+                }
+            }
+        });
     }
 
     public function messages(): array

--- a/app/Services/ParticipantService.php
+++ b/app/Services/ParticipantService.php
@@ -43,6 +43,32 @@ class ParticipantService
         return [];
     }
 
+    public function getLockReason(Participant $participant, string $fieldName): ?string
+    {
+        if ($participant->is_verified) {
+            return 'Field ini terkunci karena data sudah terverifikasi.';
+        }
+
+        if ($this->hasActiveRegistration($participant) && in_array($fieldName, ['nik', 'birth_date', 'gender'])) {
+            return 'Field ini terkunci karena peserta sudah terdaftar di event.';
+        }
+
+        return null;
+    }
+
+    public function getDeleteReason(Participant $participant): ?string
+    {
+        if ($participant->is_verified) {
+            return 'Peserta yang sudah terverifikasi tidak dapat dihapus.';
+        }
+
+        if ($this->hasActiveRegistration($participant)) {
+            return 'Peserta memiliki registrasi aktif dan tidak dapat dihapus.';
+        }
+
+        return null;
+    }
+
     private function hasActiveRegistration(Participant $participant): bool
     {
         return $participant->registrations()->whereNull('deleted_at')->exists();

--- a/resources/views/participants/edit.blade.php
+++ b/resources/views/participants/edit.blade.php
@@ -1,7 +1,24 @@
 <x-app-layout>
     @section('title', 'Edit Peserta - ' . $participant->name)
 
-    @if(count($lockedFields) > 0)
+    @if($participant->is_verified)
+        <div class="alert alert-dismissible bg-light-danger border border-danger border-dashed d-flex align-items-center p-5 mb-5">
+            <span class="svg-icon svg-icon-2 me-4">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                    <path opacity="0.3"
+                        d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20Z"
+                        fill="currentColor" />
+                    <path d="M13 7H11V13H17V11H13V7Z" fill="currentColor" />
+                </svg>
+            </span>
+            <div class="d-flex flex-column">
+                <h5 class="mb-1 text-danger">Data sudah terverifikasi</h5>
+                <span class="text-gray-600">
+                    Hanya foto yang dapat diubah. Semua field lainnya terkunci.
+                </span>
+            </div>
+        </div>
+    @elseif(count($lockedFields) > 0)
         <div class="alert alert-dismissible bg-light-warning border border-warning border-dashed d-flex align-items-center p-5 mb-5">
             <span class="svg-icon svg-icon-2 me-4">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
@@ -14,7 +31,7 @@
             <div class="d-flex flex-column">
                 <h5 class="mb-1 text-warning">Perhatian</h5>
                 <span class="text-gray-600">
-                    Beberapa field tidak dapat diubah karena peserta sudah terdaftar dalam pendaftaran aktif dan/atau sudah terverifikasi.
+                    Peserta sudah terdaftar di event. NIK, tanggal lahir, dan jenis kelamin tidak dapat diubah.
                 </span>
             </div>
         </div>
@@ -59,7 +76,8 @@
                                 Nama Lengkap
                                 @if($isNameLocked)
                                     <i class="bi bi-lock-fill text-warning ms-1" data-bs-toggle="tooltip"
-                                        data-bs-placement="right" title="Field ini terkunci dan tidak dapat diubah"></i>
+                                        data-bs-placement="right"
+                                        title="{{ $lockReasons['name'] ?? 'Field ini terkunci dan tidak dapat diubah' }}"></i>
                                 @endif
                             </label>
                             <input type="text" name="name" class="form-control form-control-solid"
@@ -105,7 +123,8 @@
                                 NIK
                                 @if($isNikLocked)
                                     <i class="bi bi-lock-fill text-warning ms-1" data-bs-toggle="tooltip"
-                                        data-bs-placement="right" title="Field ini terkunci dan tidak dapat diubah"></i>
+                                        data-bs-placement="right"
+                                        title="{{ $lockReasons['nik'] ?? 'Field ini terkunci dan tidak dapat diubah' }}"></i>
                                 @endif
                             </label>
                             <input type="text" name="nik" class="form-control form-control-solid"
@@ -126,7 +145,8 @@
                                 Tanggal Lahir
                                 @if($isBirthDateLocked)
                                     <i class="bi bi-lock-fill text-warning ms-1" data-bs-toggle="tooltip"
-                                        data-bs-placement="right" title="Field ini terkunci dan tidak dapat diubah"></i>
+                                        data-bs-placement="right"
+                                        title="{{ $lockReasons['birth_date'] ?? 'Field ini terkunci dan tidak dapat diubah' }}"></i>
                                 @endif
                             </label>
                             <input type="text" name="birth_date" class="form-control form-control-solid"
@@ -150,7 +170,8 @@
                                 Jenis Kelamin
                                 @if($isGenderLocked)
                                     <i class="bi bi-lock-fill text-warning ms-1" data-bs-toggle="tooltip"
-                                        data-bs-placement="right" title="Field ini terkunci dan tidak dapat diubah"></i>
+                                        data-bs-placement="right"
+                                        title="{{ $lockReasons['gender'] ?? 'Field ini terkunci dan tidak dapat diubah' }}"></i>
                                 @endif
                             </label>
                             <div class="d-flex flex-wrap gap-5">
@@ -181,7 +202,8 @@
                                 Provinsi
                                 @if(in_array('provinsi', $lockedFields))
                                     <i class="bi bi-lock-fill text-warning ms-1" data-bs-toggle="tooltip"
-                                        data-bs-placement="right" title="Field ini terkunci dan tidak dapat diubah"></i>
+                                        data-bs-placement="right"
+                                        title="{{ $lockReasons['provinsi'] ?? 'Field ini terkunci dan tidak dapat diubah' }}"></i>
                                 @endif
                             </label>
                             <input type="text" name="provinsi" class="form-control form-control-solid"
@@ -204,7 +226,8 @@
                                 Institusi
                                 @if(in_array('institusi', $lockedFields))
                                     <i class="bi bi-lock-fill text-warning ms-1" data-bs-toggle="tooltip"
-                                        data-bs-placement="right" title="Field ini terkunci dan tidak dapat diubah"></i>
+                                        data-bs-placement="right"
+                                        title="{{ $lockReasons['institusi'] ?? 'Field ini terkunci dan tidak dapat diubah' }}"></i>
                                 @endif
                             </label>
                             <input type="text" name="institusi" class="form-control form-control-solid"
@@ -224,7 +247,8 @@
                                 Dokumen
                                 @if($isDocumentLocked)
                                     <i class="bi bi-lock-fill text-warning ms-1" data-bs-toggle="tooltip"
-                                        data-bs-placement="right" title="Field ini terkunci dan tidak dapat diubah"></i>
+                                        data-bs-placement="right"
+                                        title="{{ $lockReasons['document'] ?? 'Field ini terkunci dan tidak dapat diubah' }}"></i>
                                 @endif
                             </label>
                             @if($participant->document)

--- a/resources/views/participants/show.blade.php
+++ b/resources/views/participants/show.blade.php
@@ -1,6 +1,42 @@
 <x-app-layout>
     @section('title', 'Detail Peserta - ' . $participant->name)
 
+    @if($hasActiveRegistration && !$participant->is_verified)
+        <div class="alert alert-dismissible bg-light-warning border border-warning border-dashed d-flex align-items-center p-5 mb-5">
+            <span class="svg-icon svg-icon-2 me-4">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                    <path opacity="0.3"
+                        d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20Z"
+                        fill="currentColor" />
+                    <path d="M13 7H11V13H17V11H13V7Z" fill="currentColor" />
+                </svg>
+            </span>
+            <div class="d-flex flex-column">
+                <h5 class="mb-1 text-warning">Peserta terdaftar di event</h5>
+                <span class="text-gray-600">
+                    NIK, tanggal lahir, dan jenis kelamin tidak dapat diubah. Peserta tidak dapat dihapus.
+                </span>
+            </div>
+        </div>
+    @elseif($participant->is_verified)
+        <div class="alert alert-dismissible bg-light-danger border border-danger border-dashed d-flex align-items-center p-5 mb-5">
+            <span class="svg-icon svg-icon-2 me-4">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                    <path opacity="0.3"
+                        d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20Z"
+                        fill="currentColor" />
+                    <path d="M13 7H11V13H17V11H13V7Z" fill="currentColor" />
+                </svg>
+            </span>
+            <div class="d-flex flex-column">
+                <h5 class="mb-1 text-danger">Data sudah terverifikasi</h5>
+                <span class="text-gray-600">
+                    Semua field terkunci kecuali foto. Peserta tidak dapat dihapus.
+                </span>
+            </div>
+        </div>
+    @endif
+
     <div class="card mb-5 mb-xl-10">
         <div class="card-body border-0 pt-9 pb-0">
             <div class="d-flex flex-wrap flex-sm-nowrap mb-3">
@@ -37,6 +73,11 @@
                                 @else
                                     <span class="badge badge-light-warning fw-bolder ms-2 fs-8">Belum</span>
                                 @endif
+                                @if($hasActiveRegistration)
+                                    <span class="badge badge-light-info fw-bolder ms-2 fs-8">
+                                        <i class="bi bi-clipboard-check me-1"></i>Terdaftar Event
+                                    </span>
+                                @endif
                             </div>
                             <span class="text-muted fw-semibold fs-6">
                                 @if($participant->nik)
@@ -49,8 +90,24 @@
                         <div class="d-flex flex-wrap">
                             <a href="{{ route('participants.edit', $participant) }}"
                                 class="btn btn-light-primary btn-sm me-2">
-                                Edit
+                                <i class="bi bi-pencil me-1"></i> Edit
                             </a>
+                            @if($canDelete)
+                                <form action="{{ route('participants.destroy', $participant) }}" method="POST"
+                                    class="d-inline" onsubmit="return confirm('Yakin ingin menghapus peserta ini?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-light-danger btn-sm me-2">
+                                        <i class="bi bi-trash me-1"></i> Hapus
+                                    </button>
+                                </form>
+                            @else
+                                <span class="btn btn-light-danger btn-sm me-2 opacity-50 cursor-default" data-bs-toggle="tooltip"
+                                    data-bs-placement="bottom" title="{{ $deleteReason ?? 'Peserta tidak dapat dihapus' }}"
+                                    style="cursor: not-allowed;">
+                                    <i class="bi bi-trash me-1"></i> Hapus
+                                </span>
+                            @endif
                             <a href="{{ route('participants.index') }}" class="btn btn-light btn-sm">
                                 Kembali
                             </a>
@@ -186,8 +243,15 @@
     </div>
 
     @push('scripts')
+        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+            new bootstrap.Tooltip(el);
+        });
+
         @if (session('success'))
-            <script>toastr.success("{{ session('success') }}");</script>
+            toastr.success("{{ session('success') }}");
+        @endif
+        @if ($errors->has('delete'))
+            toastr.error("{{ $errors->first('delete') }}");
         @endif
     @endpush
 </x-app-layout>


### PR DESCRIPTION
## Summary
- Complete BR-14 protection for participant edit and delete
- Add backend validation via `withValidator()` to reject locked field changes even from manual requests
- Add `getLockReason()` and `getDeleteReason()` to `ParticipantService` for specific, informative messages
- Separate Lock Level 1 (active registration) and Lock Level 2 (verified) warning alerts on edit/show pages
- Add delete button on show page with `canDelete` check and tooltip explaining why deletion is blocked
- Add "Terdaftar Event" badge on show page when participant has active registration

Closes #15

## Test plan
- [ ] Skenario 1: Peserta baru — semua field bisa diedit, bisa dihapus, tidak ada icon lock
- [ ] Skenario 2: Peserta dengan registrasi aktif — nik/birth_date/gender terkunci, tooltip spesifik, hapus disabled
- [ ] Skenario 3: Peserta verified — semua field terkunci kecuali foto, hapus disabled (tunggu fitur verifikasi)
- [ ] Skenario 4: Registrasi di-soft-delete — lock level 1 hilang, semua field editable lagi
- [ ] Skenario 5: Bypass backend via Postman — edit locked field harus ditolak dengan error

🤖 Generated with [Claude Code](https://claude.com/claude-code)