### PR TITLE
[PHASE 3][Frontend] UI Manajemen Event Admin

### DIFF
--- a/app/Http/Controllers/Admin/EventCategoryController.php
+++ b/app/Http/Controllers/Admin/EventCategoryController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\EventCategoryRequest;
+use App\Models\Event;
+use App\Models\EventCategory;
+
+class EventCategoryController extends Controller
+{
+    public function store(EventCategoryRequest $request, Event $event)
+    {
+        $event->categories()->create($request->validated());
+
+        return redirect()->route('admin.events.show', $event)->with('success', 'Kategori berhasil ditambahkan.');
+    }
+
+    public function edit(EventCategory $eventCategory)
+    {
+        $eventCategory->load('event');
+
+        return view('admin.event-categories.edit', compact('eventCategory'));
+    }
+
+    public function update(EventCategoryRequest $request, EventCategory $eventCategory)
+    {
+        $eventCategory->update($request->validated());
+
+        return redirect()->route('admin.events.show', $eventCategory->event)->with('success', 'Kategori berhasil diperbarui.');
+    }
+
+    public function destroy(EventCategory $eventCategory)
+    {
+        $event = $eventCategory->event;
+
+        if (! $eventCategory->canDelete()) {
+            return back()->withErrors([
+                'delete' => 'Kategori tidak dapat dihapus karena sudah ada registrasi aktif.',
+            ]);
+        }
+
+        $eventCategory->delete();
+
+        return redirect()->route('admin.events.show', $event)->with('success', 'Kategori berhasil dihapus.');
+    }
+
+    public function show(EventCategory $eventCategory)
+    {
+        $eventCategory->load(['event', 'subCategories.registrations.payment']);
+
+        return view('admin.event-categories.show', compact('eventCategory'));
+    }
+}

--- a/app/Http/Controllers/Admin/EventController.php
+++ b/app/Http/Controllers/Admin/EventController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\EventStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\EventRequest;
+use App\Models\Event;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class EventController extends Controller
+{
+    public function index()
+    {
+        $events = Event::withCount(['categories', 'payments'])
+            ->orderByDesc('event_date')
+            ->paginate(10)
+            ->withQueryString();
+
+        return view('admin.events.index', compact('events'));
+    }
+
+    public function create()
+    {
+        return view('admin.events.create', [
+            'event' => new Event(['status' => EventStatus::Draft]),
+        ]);
+    }
+
+    public function store(EventRequest $request)
+    {
+        $event = Event::create($request->validated());
+
+        return redirect()->route('admin.events.show', $event)->with('success', 'Event berhasil dibuat.');
+    }
+
+    public function show(Event $event)
+    {
+        $event->load(['categories.subCategories.registrations.payment']);
+
+        return view('admin.events.show', compact('event'));
+    }
+
+    public function edit(Event $event)
+    {
+        return view('admin.events.edit', compact('event'));
+    }
+
+    public function update(EventRequest $request, Event $event)
+    {
+        $validated = $request->validated();
+
+        if ($event->isLocked()) {
+            unset($validated['event_date'], $validated['coach_fee']);
+        }
+
+        unset($validated['status']);
+
+        $event->update($validated);
+
+        return redirect()->route('admin.events.show', $event)->with('success', 'Event berhasil diperbarui.');
+    }
+
+    public function destroy(Event $event)
+    {
+        if ($event->categories()->exists() || $event->payments()->exists()) {
+            return back()->withErrors([
+                'delete' => 'Event tidak dapat dihapus karena sudah memiliki kategori atau pembayaran.',
+            ]);
+        }
+
+        $event->delete();
+
+        return redirect()->route('admin.events.index')->with('success', 'Event berhasil dihapus.');
+    }
+
+    public function transition(Request $request, Event $event)
+    {
+        $validated = $request->validate([
+            'status' => ['required', Rule::enum(EventStatus::class)],
+        ]);
+
+        $nextStatus = EventStatus::from($validated['status']);
+
+        if (! $event->canTransitionTo($nextStatus)) {
+            return back()->withErrors([
+                'transition' => 'Transisi status tidak valid.',
+            ]);
+        }
+
+        $event->update(['status' => $nextStatus]);
+
+        return back()->with('success', 'Status event berhasil diubah.');
+    }
+}

--- a/app/Http/Controllers/Admin/SubCategoryController.php
+++ b/app/Http/Controllers/Admin/SubCategoryController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\SubCategoryRequest;
+use App\Models\EventCategory;
+use App\Models\SubCategory;
+
+class SubCategoryController extends Controller
+{
+    public function store(SubCategoryRequest $request, EventCategory $eventCategory)
+    {
+        $eventCategory->subCategories()->create($request->validated());
+
+        return redirect()->route('admin.event-categories.show', $eventCategory)->with('success', 'Sub-kategori berhasil ditambahkan.');
+    }
+
+    public function edit(SubCategory $subCategory)
+    {
+        $subCategory->load('eventCategory.event');
+
+        return view('admin.sub-categories.edit', compact('subCategory'));
+    }
+
+    public function update(SubCategoryRequest $request, SubCategory $subCategory)
+    {
+        $validated = $request->validated();
+
+        if (! $subCategory->canEditPrice()) {
+            unset($validated['price']);
+        }
+
+        $subCategory->update($validated);
+
+        return redirect()->route('admin.event-categories.show', $subCategory->eventCategory)->with('success', 'Sub-kategori berhasil diperbarui.');
+    }
+
+    public function destroy(SubCategory $subCategory)
+    {
+        $eventCategory = $subCategory->eventCategory;
+
+        if (! $subCategory->canDelete()) {
+            return back()->withErrors([
+                'delete' => 'Sub-kategori tidak dapat dihapus karena sudah ada registrasi aktif.',
+            ]);
+        }
+
+        $subCategory->delete();
+
+        return redirect()->route('admin.event-categories.show', $eventCategory)->with('success', 'Sub-kategori berhasil dihapus.');
+    }
+}

--- a/app/Http/Requests/Admin/EventCategoryRequest.php
+++ b/app/Http/Requests/Admin/EventCategoryRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\EventCategoryType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class EventCategoryRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', Rule::enum(EventCategoryType::class)],
+            'class_name' => ['required', 'string', 'max:255'],
+            'min_birth_date' => ['required', 'date'],
+            'max_birth_date' => ['required', 'date', 'after_or_equal:min_birth_date'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/EventRequest.php
+++ b/app/Http/Requests/Admin/EventRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\EventStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class EventRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        $event = $this->route('event');
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'event_date' => [
+                'required',
+                'date',
+                $event ? 'date' : 'after_or_equal:today',
+            ],
+            'registration_deadline' => ['nullable', 'date', 'before:event_date'],
+            'coach_fee' => ['required', 'numeric', 'min:0'],
+            'status' => ['required', Rule::enum(EventStatus::class)],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/SubCategoryRequest.php
+++ b/app/Http/Requests/Admin/SubCategoryRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\SubCategoryGender;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class SubCategoryRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'gender' => ['required', Rule::enum(SubCategoryGender::class)],
+            'price' => ['required', 'numeric', 'min:0'],
+            'min_participants' => ['required', 'integer', 'min:1'],
+            'max_participants' => ['required', 'integer', 'min:min_participants'],
+        ];
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -38,4 +38,52 @@ class Event extends Model
     {
         return $this->hasMany(Payment::class);
     }
+
+    public function allowedStatusTransitions(): array
+    {
+        return [
+            EventStatus::Draft->value => [EventStatus::RegistrationOpen->value],
+            EventStatus::RegistrationOpen->value => [EventStatus::RegistrationClosed->value],
+            EventStatus::RegistrationClosed->value => [EventStatus::Ongoing->value],
+            EventStatus::Ongoing->value => [EventStatus::Completed->value],
+            EventStatus::Completed->value => [],
+        ];
+    }
+
+    public function canTransitionTo(EventStatus $status): bool
+    {
+        return in_array($status->value, $this->allowedStatusTransitions()[$this->status->value] ?? [], true);
+    }
+
+    public function isLocked(): bool
+    {
+        return in_array($this->status, [EventStatus::Ongoing, EventStatus::Completed], true);
+    }
+
+    public function canEditImportantFields(): bool
+    {
+        return ! $this->isLocked();
+    }
+
+    public function statusLabel(): string
+    {
+        return match ($this->status) {
+            EventStatus::Draft => 'Draft',
+            EventStatus::RegistrationOpen => 'Registration Open',
+            EventStatus::RegistrationClosed => 'Registration Closed',
+            EventStatus::Ongoing => 'Ongoing',
+            EventStatus::Completed => 'Completed',
+        };
+    }
+
+    public function statusBadgeClass(): string
+    {
+        return match ($this->status) {
+            EventStatus::Draft => 'badge-light-secondary',
+            EventStatus::RegistrationOpen => 'badge-light-success',
+            EventStatus::RegistrationClosed => 'badge-light-warning',
+            EventStatus::Ongoing => 'badge-light-primary',
+            EventStatus::Completed => 'badge-light-dark',
+        };
+    }
 }

--- a/app/Models/EventCategory.php
+++ b/app/Models/EventCategory.php
@@ -38,4 +38,21 @@ class EventCategory extends Model
     {
         return $this->hasMany(SubCategory::class);
     }
+
+    public function hasActiveRegistrations(): bool
+    {
+        return $this->subCategories()
+            ->whereHas('registrations', fn($query) => $query->whereNull('deleted_at'))
+            ->exists();
+    }
+
+    public function canDelete(): bool
+    {
+        return ! $this->hasActiveRegistrations();
+    }
+
+    public function readableBirthRange(): string
+    {
+        return 'Lahir: ' . $this->min_birth_date?->translatedFormat('j M Y') . ' - ' . $this->max_birth_date?->translatedFormat('j M Y');
+    }
 }

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -45,4 +45,29 @@ class SubCategory extends Model
     {
         return $this->max_participants > 1;
     }
+
+    public function hasActiveRegistrations(): bool
+    {
+        return $this->registrations()->whereNull('deleted_at')->exists();
+    }
+
+    public function hasPayments(): bool
+    {
+        return $this->registrations()->whereHas('payment')->exists();
+    }
+
+    public function canDelete(): bool
+    {
+        return ! $this->hasActiveRegistrations();
+    }
+
+    public function canEditPrice(): bool
+    {
+        return ! $this->hasPayments();
+    }
+
+    public function labelType(): string
+    {
+        return $this->isTeam() ? 'Beregu' : 'Individu';
+    }
 }

--- a/resources/views/admin/event-categories/edit.blade.php
+++ b/resources/views/admin/event-categories/edit.blade.php
@@ -1,0 +1,74 @@
+<x-app-layout>
+    @section('title', 'Edit Kategori - ' . $eventCategory->class_name)
+
+    <form action="{{ route('admin.event-categories.update', $eventCategory) }}" method="POST" class="form">
+        @csrf
+        @method('PUT')
+        <div class="card mb-5">
+            <div class="card-header border-0 pt-5">
+                <h3 class="card-title align-items-start flex-column">
+                    <span class="card-label fw-bold text-dark">Edit Kategori</span>
+                    <span class="text-muted mt-1 fw-semibold fs-7">{{ $eventCategory->event->name }}</span>
+                </h3>
+            </div>
+            <div class="card-body py-5">
+                <div class="row g-4">
+                    <div class="col-md-2">
+                        <label class="required form-label">Type</label>
+                        <select name="type" class="form-select form-select-solid">
+                            <option value="Open" @selected(old('type', $eventCategory->type->value) === 'Open')>Open</option>
+                            <option value="Festival" @selected(old('type', $eventCategory->type->value) === 'Festival')>Festival</option>
+                        </select>
+                        @error('type')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-3">
+                        <label class="required form-label">Class Name</label>
+                        <input type="text" name="class_name" class="form-control form-control-solid"
+                            value="{{ old('class_name', $eventCategory->class_name) }}">
+                        @error('class_name')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-3">
+                        <label class="required form-label">Min Birth Date</label>
+                        <input type="text" name="min_birth_date" class="form-control form-control-solid"
+                            id="kt_min_birth_date"
+                            value="{{ old('min_birth_date', $eventCategory->min_birth_date?->format('Y-m-d')) }}">
+                        @error('min_birth_date')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-3">
+                        <label class="required form-label">Max Birth Date</label>
+                        <input type="text" name="max_birth_date" class="form-control form-control-solid"
+                            id="kt_max_birth_date"
+                            value="{{ old('max_birth_date', $eventCategory->max_birth_date?->format('Y-m-d')) }}">
+                        @error('max_birth_date')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="d-flex justify-content-end">
+            <a href="{{ route('admin.events.show', $eventCategory->event) }}"
+                class="btn btn-light btn-active-light-primary me-2">Batal</a>
+            <button type="submit" class="btn btn-primary">Simpan</button>
+        </div>
+    </form>
+
+    @push('scripts')
+        <script>
+            flatpickr('#kt_min_birth_date', {
+                dateFormat: 'Y-m-d',
+                maxDate: 'today'
+            });
+            flatpickr('#kt_max_birth_date', {
+                dateFormat: 'Y-m-d',
+                maxDate: 'today'
+            });
+        </script>
+    @endpush
+</x-app-layout>

--- a/resources/views/admin/event-categories/show.blade.php
+++ b/resources/views/admin/event-categories/show.blade.php
@@ -1,0 +1,290 @@
+<x-app-layout>
+    @section('title', 'Detail Kategori - ' . $eventCategory->class_name)
+
+    <style>
+        .k-card {
+            background: #fff;
+            border: 1px dashed #e4e6ef;
+            border-radius: 8px;
+            margin-bottom: 10px;
+            overflow: hidden
+        }
+
+        .k-card-hd {
+            padding: 12px 14px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
+            user-select: none
+        }
+
+        .k-card-av {
+            width: 42px;
+            height: 42px;
+            border-radius: 50%;
+            overflow: hidden;
+            flex-shrink: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            font-size: .95rem
+        }
+
+        .k-card-nm {
+            flex: 1;
+            min-width: 0;
+            font-weight: 700;
+            font-size: .88rem;
+            color: #3f4254;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis
+        }
+
+        .k-card-em {
+            font-size: .72rem;
+            color: #b5b5c3;
+            font-weight: 600;
+            margin-top: 2px
+        }
+
+        .k-card-arr {
+            flex-shrink: 0;
+            color: #b5b5c3;
+            transition: transform .25s ease;
+            font-size: .7rem
+        }
+
+        .k-card.open .k-card-arr {
+            transform: rotate(180deg)
+        }
+
+        .k-card-bd {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height .3s cubic-bezier(.4, 0, .2, 1)
+        }
+
+        .k-card.open .k-card-bd {
+            max-height: 500px
+        }
+
+        .k-card-dt {
+            padding: 0 14px 12px
+        }
+
+        .k-card-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 7px 0;
+            border-bottom: 1px solid #f3f6f9
+        }
+
+        .k-card-row:last-child {
+            border-bottom: none
+        }
+
+        .k-card-lbl {
+            font-size: .72rem;
+            color: #b5b5c3;
+            font-weight: 600
+        }
+
+        .k-card-val {
+            font-size: .78rem;
+            color: #3f4254;
+            font-weight: 600;
+            text-align: right;
+            max-width: 60%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap
+        }
+
+        .k-card-acts {
+            display: flex;
+            gap: 6px;
+            padding: 6px 14px 12px;
+            border-top: 1px dashed #e4e6ef
+        }
+
+        .k-card-acts .btn {
+            flex: 1;
+            font-size: .72rem;
+            padding: 6px 0;
+            border-radius: 6px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 4px
+        }
+    </style>
+
+    <div class="card mb-5">
+        <div class="card-header border-0 pt-6">
+            <div class="card-title">
+                <h3 class="card-label fw-bold text-dark">{{ $eventCategory->class_name }}</h3>
+            </div>
+            <div class="card-toolbar d-flex gap-2 flex-wrap">
+                <a href="{{ route('admin.event-categories.edit', $eventCategory) }}"
+                    class="btn btn-light-warning btn-sm">Edit Kategori</a>
+            </div>
+        </div>
+        <div class="card-body py-5">
+            <div class="row gy-4 mb-4">
+                <div class="col-md-4">
+                    <div class="text-muted fs-7">Event</div>
+                    <div class="fw-bold">{{ $eventCategory->event->name }}</div>
+                </div>
+                <div class="col-md-2">
+                    <div class="text-muted fs-7">Type</div>
+                    <div class="fw-bold">{{ $eventCategory->type->value }}</div>
+                </div>
+                <div class="col-md-6">
+                    <div class="text-muted fs-7">Rentang Lahir</div>
+                    <div class="fw-bold">{{ $eventCategory->readableBirthRange() }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header border-0 pt-6">
+            <div class="card-title">
+                <h3 class="card-label fw-bold text-dark">Sub-Kategori</h3>
+            </div>
+        </div>
+        <div class="card-body py-4">
+            <form action="{{ route('admin.event-categories.sub-categories.store', $eventCategory) }}" method="POST"
+                class="row g-4 mb-6">
+                @csrf
+                <div class="col-md-3">
+                    <label class="required form-label">Name</label>
+                    <input type="text" name="name" class="form-control form-control-solid"
+                        value="{{ old('name') }}" placeholder="Kumite -55kg">
+                    @error('name')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-2">
+                    <label class="required form-label">Gender</label>
+                    <select name="gender" class="form-select form-select-solid">
+                        <option value="M">M</option>
+                        <option value="F">F</option>
+                        <option value="Mixed">Mixed</option>
+                    </select>
+                    @error('gender')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-2">
+                    <label class="required form-label">Price</label>
+                    <input type="number" name="price" class="form-control form-control-solid"
+                        value="{{ old('price', 0) }}" min="0" step="0.01">
+                    @error('price')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-2">
+                    <label class="required form-label">Min Participants</label>
+                    <input type="number" name="min_participants" class="form-control form-control-solid"
+                        value="{{ old('min_participants', 1) }}" min="1">
+                    @error('min_participants')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-2">
+                    <label class="required form-label">Max Participants</label>
+                    <input type="number" name="max_participants" class="form-control form-control-solid"
+                        value="{{ old('max_participants', 1) }}" min="1">
+                    @error('max_participants')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-1 d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary w-100">Tambah</button>
+                </div>
+            </form>
+
+            <div class="table-responsive d-none d-lg-block">
+                <table class="table align-middle table-row-dashed fs-6 gy-5">
+                    <thead>
+                        <tr class="text-start text-muted fw-bolder fs-7 text-uppercase gs-0">
+                            <th>Name</th>
+                            <th>Gender</th>
+                            <th>Price</th>
+                            <th>Peserta</th>
+                            <th>Label</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($eventCategory->subCategories as $subCategory)
+                            <tr>
+                                <td>{{ $subCategory->name }}</td>
+                                <td>{{ $subCategory->gender->value }}</td>
+                                <td>{{ number_format($subCategory->price, 2, ',', '.') }}</td>
+                                <td>{{ $subCategory->min_participants }} - {{ $subCategory->max_participants }}</td>
+                                <td><span
+                                        class="badge {{ $subCategory->isTeam() ? 'badge-light-primary' : 'badge-light-secondary' }}">{{ $subCategory->labelType() }}</span>
+                                </td>
+                                <td class="text-end">
+                                    <a href="{{ route('admin.sub-categories.edit', $subCategory) }}"
+                                        class="btn btn-light-warning btn-sm">Edit</a>
+                                    <form action="{{ route('admin.sub-categories.destroy', $subCategory) }}"
+                                        method="POST" class="d-inline"
+                                        onsubmit="return confirm('Hapus sub-kategori ini?')">
+                                        @csrf @method('DELETE')
+                                        <button type="submit" class="btn btn-light-danger btn-sm">Hapus</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center text-muted py-10">Belum ada sub-kategori</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="d-block d-lg-none">
+                @forelse ($eventCategory->subCategories as $subCategory)
+                    <div class="k-card">
+                        <div class="k-card-hd" onclick="this.parentElement.classList.toggle('open')">
+                            <div class="k-card-av bg-light-success text-success">
+                                {{ strtoupper(substr($subCategory->name, 0, 1)) }}</div>
+                            <div style="flex:1;min-width:0">
+                                <div class="k-card-nm">{{ $subCategory->name }}</div>
+                                <div class="k-card-em">{{ $subCategory->labelType() }}</div>
+                            </div>
+                            <div class="k-card-arr"><i class="bi bi-chevron-down"></i></div>
+                        </div>
+                        <div class="k-card-bd">
+                            <div class="k-card-dt">
+                                <div class="k-card-row"><span class="k-card-lbl">Gender</span><span
+                                        class="k-card-val">{{ $subCategory->gender->value }}</span></div>
+                                <div class="k-card-row"><span class="k-card-lbl">Price</span><span
+                                        class="k-card-val">{{ number_format($subCategory->price, 2, ',', '.') }}</span>
+                                </div>
+                                <div class="k-card-row"><span class="k-card-lbl">Peserta</span><span
+                                        class="k-card-val">{{ $subCategory->min_participants }} -
+                                        {{ $subCategory->max_participants }}</span></div>
+                            </div>
+                            <div class="k-card-acts">
+                                <a href="{{ route('admin.sub-categories.edit', $subCategory) }}"
+                                    class="btn btn-light-warning">Edit</a>
+                            </div>
+                        </div>
+                    </div>
+                @empty
+                    <div class="text-center text-muted py-10">Belum ada sub-kategori</div>
+                @endforelse
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/events/_form.blade.php
+++ b/resources/views/admin/events/_form.blade.php
@@ -1,0 +1,70 @@
+@php
+    $isLocked = $event?->exists && $event->isLocked();
+@endphp
+
+<div class="row mb-7">
+    <div class="col-md-4 fv-row">
+        <label class="required form-label">Tanggal Event</label>
+        <input type="text" name="event_date" class="form-control form-control-solid"
+            value="{{ old('event_date', $event->event_date?->format('Y-m-d')) }}" id="kt_event_date"
+            {{ $isLocked ? 'disabled' : '' }}>
+        @if ($isLocked)
+            <input type="hidden" name="event_date" value="{{ $event->event_date?->format('Y-m-d') }}">
+        @endif
+        @error('event_date')
+            <span class="text-danger small">{{ $message }}</span>
+        @enderror
+    </div>
+    <div class="col-md-4 fv-row">
+        <label class="form-label">Registration Deadline</label>
+        <input type="text" name="registration_deadline" class="form-control form-control-solid"
+            value="{{ old('registration_deadline', $event->registration_deadline?->format('Y-m-d H:i')) }}"
+            id="kt_deadline_date" placeholder="Opsional">
+        @error('registration_deadline')
+            <span class="text-danger small">{{ $message }}</span>
+        @enderror
+    </div>
+    <div class="col-md-4 fv-row">
+        <label class="required form-label">Coach Fee</label>
+        <input type="number" name="coach_fee" class="form-control form-control-solid"
+            value="{{ old('coach_fee', $event->coach_fee) }}" min="0" step="0.01"
+            {{ $isLocked ? 'disabled' : '' }}>
+        @if ($isLocked)
+            <input type="hidden" name="coach_fee" value="{{ $event->coach_fee }}">
+        @endif
+        @error('coach_fee')
+            <span class="text-danger small">{{ $message }}</span>
+        @enderror
+    </div>
+</div>
+
+<div class="row mb-7">
+    <div class="col-md-6 fv-row">
+        <label class="required form-label">Nama Event</label>
+        <input type="text" name="name" class="form-control form-control-solid"
+            value="{{ old('name', $event->name) }}">
+        @error('name')
+            <span class="text-danger small">{{ $message }}</span>
+        @enderror
+    </div>
+    <div class="col-md-6 fv-row">
+        <label class="required form-label">Status</label>
+        @if ($event->exists)
+            <div class="form-control form-control-solid bg-light d-flex align-items-center justify-content-between">
+                <span>{{ $event->statusLabel() }}</span>
+                <span class="badge {{ $event->statusBadgeClass() }}">{{ $event->status->value }}</span>
+            </div>
+            <input type="hidden" name="status" value="{{ $event->status->value }}">
+        @else
+            <select name="status" class="form-select form-select-solid">
+                @foreach (\App\Enums\EventStatus::cases() as $status)
+                    <option value="{{ $status->value }}" @selected(old('status', $event->status?->value ?? 'draft') === $status->value)>
+                        {{ ucfirst(str_replace('_', ' ', $status->value)) }}</option>
+                @endforeach
+            </select>
+        @endif
+        @error('status')
+            <span class="text-danger small">{{ $message }}</span>
+        @enderror
+    </div>
+</div>

--- a/resources/views/admin/events/create.blade.php
+++ b/resources/views/admin/events/create.blade.php
@@ -1,0 +1,26 @@
+<x-app-layout>
+    @section('title', 'Tambah Event')
+
+    <form action="{{ route('admin.events.store') }}" method="POST" class="form">
+        @csrf
+        @include('admin.events._form', ['event' => $event])
+
+        <div class="d-flex justify-content-end">
+            <a href="{{ route('admin.events.index') }}" class="btn btn-light btn-active-light-primary me-2">Batal</a>
+            <button type="submit" class="btn btn-primary">Simpan</button>
+        </div>
+    </form>
+
+    @push('scripts')
+        <script>
+            flatpickr('#kt_event_date', {
+                dateFormat: 'Y-m-d',
+                minDate: 'today'
+            });
+            flatpickr('#kt_deadline_date', {
+                enableTime: true,
+                dateFormat: 'Y-m-d H:i'
+            });
+        </script>
+    @endpush
+</x-app-layout>

--- a/resources/views/admin/events/edit.blade.php
+++ b/resources/views/admin/events/edit.blade.php
@@ -1,0 +1,39 @@
+<x-app-layout>
+    @section('title', 'Edit Event - ' . $event->name)
+
+    @if ($event->isLocked())
+        <div
+            class="alert alert-dismissible bg-light-warning border border-warning border-dashed d-flex align-items-center p-5 mb-5">
+            <div class="d-flex flex-column">
+                <h5 class="mb-1 text-warning">Event terkunci</h5>
+                <span class="text-gray-600">Tanggal event dan coach fee tidak dapat diubah karena event sudah ongoing
+                    atau completed.</span>
+            </div>
+        </div>
+    @endif
+
+    <form action="{{ route('admin.events.update', $event) }}" method="POST" class="form">
+        @csrf
+        @method('PUT')
+        @include('admin.events._form', ['event' => $event])
+
+        <div class="d-flex justify-content-end">
+            <a href="{{ route('admin.events.show', $event) }}"
+                class="btn btn-light btn-active-light-primary me-2">Batal</a>
+            <button type="submit" class="btn btn-primary">Simpan Perubahan</button>
+        </div>
+    </form>
+
+    @push('scripts')
+        <script>
+            flatpickr('#kt_event_date', {
+                dateFormat: 'Y-m-d',
+                minDate: 'today'
+            });
+            flatpickr('#kt_deadline_date', {
+                enableTime: true,
+                dateFormat: 'Y-m-d H:i'
+            });
+        </script>
+    @endpush
+</x-app-layout>

--- a/resources/views/admin/events/index.blade.php
+++ b/resources/views/admin/events/index.blade.php
@@ -1,0 +1,259 @@
+<x-app-layout>
+    @section('title', 'Manajemen Event')
+
+    <div class="card">
+        <div class="card-header border-0 pt-6">
+            <div class="card-title">
+                <h3 class="card-label fw-bold text-dark">Manajemen Event</h3>
+            </div>
+            <div class="card-toolbar">
+                <a href="{{ route('admin.events.create') }}" class="btn btn-primary d-flex align-items-center">
+                    <span class="svg-icon svg-icon-2 me-2">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                            fill="none">
+                            <rect opacity="0.5" x="11.364" y="20.364" width="16" height="2" rx="1"
+                                transform="rotate(-90 11.364 20.364)" fill="currentColor" />
+                            <rect x="4.36396" y="11.364" width="16" height="2" rx="1"
+                                fill="currentColor" />
+                        </svg>
+                    </span>
+                    Tambah Event
+                </a>
+            </div>
+        </div>
+
+        <div class="card-body py-4">
+            <div class="table-responsive d-none d-lg-block">
+                <table class="table align-middle table-row-dashed fs-6 gy-5">
+                    <thead>
+                        <tr class="text-start text-muted fw-bolder fs-7 text-uppercase gs-0">
+                            <th class="min-w-200px">Nama</th>
+                            <th class="min-w-125px">Tanggal</th>
+                            <th class="min-w-125px">Deadline</th>
+                            <th class="min-w-125px">Coach Fee</th>
+                            <th class="min-w-125px">Kategori</th>
+                            <th class="min-w-125px">Status</th>
+                            <th class="text-end min-w-150px">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody class="text-gray-600 fw-bold">
+                        @forelse ($events as $event)
+                            <tr>
+                                <td>
+                                    <a href="{{ route('admin.events.show', $event) }}"
+                                        class="text-gray-800 text-hover-primary fw-bold">{{ $event->name }}</a>
+                                </td>
+                                <td>{{ $event->event_date?->format('d M Y') ?? '-' }}</td>
+                                <td>{{ $event->registration_deadline?->format('d M Y H:i') ?? '-' }}</td>
+                                <td>{{ number_format($event->coach_fee, 2, ',', '.') }}</td>
+                                <td>{{ $event->categories_count }}</td>
+                                <td>
+                                    <span
+                                        class="badge {{ $event->statusBadgeClass() }}">{{ $event->statusLabel() }}</span>
+                                </td>
+                                <td class="text-end">
+                                    <div class="d-flex justify-content-end flex-shrink-0 gap-2">
+                                        <a href="{{ route('admin.events.show', $event) }}"
+                                            class="btn btn-light-primary btn-sm">Detail</a>
+                                        <a href="{{ route('admin.events.edit', $event) }}"
+                                            class="btn btn-light-warning btn-sm">Edit</a>
+                                        <form action="{{ route('admin.events.destroy', $event) }}" method="POST"
+                                            onsubmit="return confirm('Hapus event ini?')">
+                                            @csrf @method('DELETE')
+                                            <button type="submit" class="btn btn-light-danger btn-sm">Hapus</button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="text-center text-muted py-10">Belum ada event</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="d-block d-lg-none">
+                @forelse ($events as $event)
+                    <div class="k-card">
+                        <div class="k-card-hd" onclick="this.parentElement.classList.toggle('open')">
+                            <div class="k-card-av bg-light-primary text-primary">E</div>
+                            <div style="flex:1;min-width:0">
+                                <div class="k-card-nm">{{ $event->name }}</div>
+                                <div class="k-card-em">{{ $event->event_date?->format('d M Y') ?? '-' }}</div>
+                            </div>
+                            <div class="k-card-arr"><i class="bi bi-chevron-down"></i></div>
+                        </div>
+                        <div class="k-card-bd">
+                            <div class="k-card-dt">
+                                <div class="k-card-row"><span class="k-card-lbl">Deadline</span><span
+                                        class="k-card-val">{{ $event->registration_deadline?->format('d M Y H:i') ?? '-' }}</span>
+                                </div>
+                                <div class="k-card-row"><span class="k-card-lbl">Coach Fee</span><span
+                                        class="k-card-val">{{ number_format($event->coach_fee, 2, ',', '.') }}</span>
+                                </div>
+                                <div class="k-card-row"><span class="k-card-lbl">Status</span><span
+                                        class="k-card-val"><span
+                                            class="badge {{ $event->statusBadgeClass() }}">{{ $event->statusLabel() }}</span></span>
+                                </div>
+                            </div>
+                            <div class="k-card-acts">
+                                <a href="{{ route('admin.events.show', $event) }}"
+                                    class="btn btn-light-primary">Detail</a>
+                                <a href="{{ route('admin.events.edit', $event) }}"
+                                    class="btn btn-light-warning">Edit</a>
+                                <form action="{{ route('admin.events.destroy', $event) }}" method="POST"
+                                    onsubmit="return confirm('Hapus event ini?')">
+                                    @csrf @method('DELETE')
+                                    <button type="submit" class="btn btn-light-danger">Hapus</button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                @empty
+                    <div class="text-center text-muted py-10">Belum ada event</div>
+                @endforelse
+            </div>
+
+            @if ($events->count() > 0)
+                <div class="row">
+                    <div
+                        class="col-sm-12 col-md-5 d-flex align-items-center justify-content-center justify-content-md-start">
+                        <div class="dataTables_info">Menampilkan {{ $events->firstItem() }} sampai
+                            {{ $events->lastItem() }} dari {{ $events->total() }} data</div>
+                    </div>
+                    <div
+                        class="col-sm-12 col-md-7 d-flex align-items-center justify-content-center justify-content-md-end">
+                        {{ $events->links() }}
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+
+    @push('scripts')
+        <style>
+            .k-card {
+                background: #fff;
+                border: 1px dashed #e4e6ef;
+                border-radius: 8px;
+                margin-bottom: 10px;
+                overflow: hidden
+            }
+
+            .k-card-hd {
+                padding: 12px 14px;
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                cursor: pointer;
+                -webkit-tap-highlight-color: transparent;
+                user-select: none
+            }
+
+            .k-card-av {
+                width: 42px;
+                height: 42px;
+                border-radius: 50%;
+                overflow: hidden;
+                flex-shrink: 0;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-weight: 700;
+                font-size: .95rem
+            }
+
+            .k-card-nm {
+                flex: 1;
+                min-width: 0;
+                font-weight: 700;
+                font-size: .88rem;
+                color: #3f4254;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis
+            }
+
+            .k-card-em {
+                font-size: .72rem;
+                color: #b5b5c3;
+                font-weight: 600;
+                margin-top: 2px
+            }
+
+            .k-card-arr {
+                flex-shrink: 0;
+                color: #b5b5c3;
+                transition: transform .25s ease;
+                font-size: .7rem
+            }
+
+            .k-card.open .k-card-arr {
+                transform: rotate(180deg)
+            }
+
+            .k-card-bd {
+                max-height: 0;
+                overflow: hidden;
+                transition: max-height .3s cubic-bezier(.4, 0, .2, 1)
+            }
+
+            .k-card.open .k-card-bd {
+                max-height: 500px
+            }
+
+            .k-card-dt {
+                padding: 0 14px 12px
+            }
+
+            .k-card-row {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                padding: 7px 0;
+                border-bottom: 1px solid #f3f6f9
+            }
+
+            .k-card-row:last-child {
+                border-bottom: none
+            }
+
+            .k-card-lbl {
+                font-size: .72rem;
+                color: #b5b5c3;
+                font-weight: 600
+            }
+
+            .k-card-val {
+                font-size: .78rem;
+                color: #3f4254;
+                font-weight: 600;
+                text-align: right;
+                max-width: 60%;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap
+            }
+
+            .k-card-acts {
+                display: flex;
+                gap: 6px;
+                padding: 6px 14px 12px;
+                border-top: 1px dashed #e4e6ef
+            }
+
+            .k-card-acts .btn {
+                flex: 1;
+                font-size: .72rem;
+                padding: 6px 0;
+                border-radius: 6px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 4px
+            }
+        </style>
+    @endpush
+</x-app-layout>

--- a/resources/views/admin/events/show.blade.php
+++ b/resources/views/admin/events/show.blade.php
@@ -1,0 +1,332 @@
+<x-app-layout>
+    @section('title', 'Detail Event - ' . $event->name)
+
+    <style>
+        .k-card {
+            background: #fff;
+            border: 1px dashed #e4e6ef;
+            border-radius: 8px;
+            margin-bottom: 10px;
+            overflow: hidden
+        }
+
+        .k-card-hd {
+            padding: 12px 14px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
+            user-select: none
+        }
+
+        .k-card-av {
+            width: 42px;
+            height: 42px;
+            border-radius: 50%;
+            overflow: hidden;
+            flex-shrink: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            font-size: .95rem
+        }
+
+        .k-card-nm {
+            flex: 1;
+            min-width: 0;
+            font-weight: 700;
+            font-size: .88rem;
+            color: #3f4254;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis
+        }
+
+        .k-card-em {
+            font-size: .72rem;
+            color: #b5b5c3;
+            font-weight: 600;
+            margin-top: 2px
+        }
+
+        .k-card-arr {
+            flex-shrink: 0;
+            color: #b5b5c3;
+            transition: transform .25s ease;
+            font-size: .7rem
+        }
+
+        .k-card.open .k-card-arr {
+            transform: rotate(180deg)
+        }
+
+        .k-card-bd {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height .3s cubic-bezier(.4, 0, .2, 1)
+        }
+
+        .k-card.open .k-card-bd {
+            max-height: 500px
+        }
+
+        .k-card-dt {
+            padding: 0 14px 12px
+        }
+
+        .k-card-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 7px 0;
+            border-bottom: 1px solid #f3f6f9
+        }
+
+        .k-card-row:last-child {
+            border-bottom: none
+        }
+
+        .k-card-lbl {
+            font-size: .72rem;
+            color: #b5b5c3;
+            font-weight: 600
+        }
+
+        .k-card-val {
+            font-size: .78rem;
+            color: #3f4254;
+            font-weight: 600;
+            text-align: right;
+            max-width: 60%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap
+        }
+
+        .k-card-acts {
+            display: flex;
+            gap: 6px;
+            padding: 6px 14px 12px;
+            border-top: 1px dashed #e4e6ef
+        }
+
+        .k-card-acts .btn {
+            flex: 1;
+            font-size: .72rem;
+            padding: 6px 0;
+            border-radius: 6px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 4px
+        }
+    </style>
+
+    <div class="card mb-5">
+        <div class="card-header border-0 pt-6">
+            <div class="card-title">
+                <h3 class="card-label fw-bold text-dark">{{ $event->name }}</h3>
+            </div>
+            <div class="card-toolbar d-flex gap-2 flex-wrap">
+                <a href="{{ route('admin.events.edit', $event) }}" class="btn btn-light-warning btn-sm">Edit Event</a>
+                <form action="{{ route('admin.events.destroy', $event) }}" method="POST"
+                    onsubmit="return confirm('Hapus event ini?')">
+                    @csrf @method('DELETE')
+                    <button type="submit" class="btn btn-light-danger btn-sm">Hapus</button>
+                </form>
+                @if ($event->canTransitionTo(\App\Enums\EventStatus::RegistrationOpen))
+                    <form action="{{ route('admin.events.transition', $event) }}" method="POST">
+                        @csrf
+                        @method('PATCH')
+                        <input type="hidden" name="status" value="registration_open">
+                        <button type="submit" class="btn btn-light-success btn-sm"
+                            onclick="return confirm('Ubah status menjadi registration open?')">Open
+                            Registration</button>
+                    </form>
+                @elseif($event->canTransitionTo(\App\Enums\EventStatus::RegistrationClosed))
+                    <form action="{{ route('admin.events.transition', $event) }}" method="POST">
+                        @csrf
+                        @method('PATCH')
+                        <input type="hidden" name="status" value="registration_closed">
+                        <button type="submit" class="btn btn-light-warning btn-sm"
+                            onclick="return confirm('Tutup pendaftaran?')">Close Registration</button>
+                    </form>
+                @elseif($event->canTransitionTo(\App\Enums\EventStatus::Ongoing))
+                    <form action="{{ route('admin.events.transition', $event) }}" method="POST">
+                        @csrf
+                        @method('PATCH')
+                        <input type="hidden" name="status" value="ongoing">
+                        <button type="submit" class="btn btn-light-primary btn-sm"
+                            onclick="return confirm('Ubah status menjadi ongoing?')">Start Event</button>
+                    </form>
+                @elseif($event->canTransitionTo(\App\Enums\EventStatus::Completed))
+                    <form action="{{ route('admin.events.transition', $event) }}" method="POST">
+                        @csrf
+                        @method('PATCH')
+                        <input type="hidden" name="status" value="completed">
+                        <button type="submit" class="btn btn-light-dark btn-sm"
+                            onclick="return confirm('Tandai event selesai?')">Complete</button>
+                    </form>
+                @endif
+            </div>
+        </div>
+        <div class="card-body py-5">
+            <div class="row gy-4 mb-4">
+                <div class="col-md-3">
+                    <div class="text-muted fs-7">Tanggal Event</div>
+                    <div class="fw-bold">{{ $event->event_date?->format('d M Y') ?? '-' }}</div>
+                </div>
+                <div class="col-md-3">
+                    <div class="text-muted fs-7">Deadline</div>
+                    <div class="fw-bold">{{ $event->registration_deadline?->format('d M Y H:i') ?? '-' }}</div>
+                </div>
+                <div class="col-md-3">
+                    <div class="text-muted fs-7">Coach Fee</div>
+                    <div class="fw-bold">{{ number_format($event->coach_fee, 2, ',', '.') }}</div>
+                </div>
+                <div class="col-md-3">
+                    <div class="text-muted fs-7">Status</div>
+                    <div class="fw-bold"><span
+                            class="badge {{ $event->statusBadgeClass() }}">{{ $event->statusLabel() }}</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header border-0 pt-6">
+            <div class="card-title">
+                <h3 class="card-label fw-bold text-dark">Kategori Event</h3>
+            </div>
+        </div>
+        <div class="card-body py-4">
+            <form action="{{ route('admin.events.categories.store', $event) }}" method="POST" class="row g-4 mb-6">
+                @csrf
+                <div class="col-md-2">
+                    <label class="required form-label">Type</label>
+                    <select name="type" class="form-select form-select-solid">
+                        <option value="Open" @selected(old('type') === 'Open')>Open</option>
+                        <option value="Festival" @selected(old('type') === 'Festival')>Festival</option>
+                    </select>
+                    @error('type')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-3">
+                    <label class="required form-label">Class Name</label>
+                    <input type="text" name="class_name" class="form-control form-control-solid"
+                        value="{{ old('class_name') }}">
+                    @error('class_name')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-3">
+                    <label class="required form-label">Min Birth Date</label>
+                    <input type="text" name="min_birth_date" class="form-control form-control-solid"
+                        id="kt_min_birth_date" value="{{ old('min_birth_date') }}">
+                    @error('min_birth_date')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-3">
+                    <label class="required form-label">Max Birth Date</label>
+                    <input type="text" name="max_birth_date" class="form-control form-control-solid"
+                        id="kt_max_birth_date" value="{{ old('max_birth_date') }}">
+                    @error('max_birth_date')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-1 d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary w-100">Tambah</button>
+                </div>
+            </form>
+
+            <div class="table-responsive d-none d-lg-block">
+                <table class="table align-middle table-row-dashed fs-6 gy-5">
+                    <thead>
+                        <tr class="text-start text-muted fw-bolder fs-7 text-uppercase gs-0">
+                            <th>Type</th>
+                            <th>Class</th>
+                            <th>Range Lahir</th>
+                            <th>Sub Category</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($event->categories as $category)
+                            <tr>
+                                <td><span class="badge badge-light-info">{{ $category->type->value }}</span></td>
+                                <td><a href="{{ route('admin.event-categories.show', $category) }}"
+                                        class="text-dark text-hover-primary fw-bold">{{ $category->class_name }}</a>
+                                </td>
+                                <td>{{ $category->readableBirthRange() }}</td>
+                                <td>{{ $category->subCategories->count() }}</td>
+                                <td class="text-end">
+                                    <a href="{{ route('admin.event-categories.edit', $category) }}"
+                                        class="btn btn-light-warning btn-sm">Edit</a>
+                                    <form action="{{ route('admin.event-categories.destroy', $category) }}"
+                                        method="POST" class="d-inline"
+                                        onsubmit="return confirm('Hapus kategori ini?')">
+                                        @csrf @method('DELETE')
+                                        <button type="submit" class="btn btn-light-danger btn-sm">Hapus</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="5" class="text-center text-muted py-10">Belum ada kategori</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="d-block d-lg-none">
+                @forelse ($event->categories as $category)
+                    <div class="k-card">
+                        <div class="k-card-hd" onclick="this.parentElement.classList.toggle('open')">
+                            <div class="k-card-av bg-light-info text-info">
+                                {{ strtoupper(substr($category->class_name, 0, 1)) }}</div>
+                            <div style="flex:1;min-width:0">
+                                <div class="k-card-nm">{{ $category->class_name }}</div>
+                                <div class="k-card-em">{{ $category->readableBirthRange() }}</div>
+                            </div>
+                            <div class="k-card-arr"><i class="bi bi-chevron-down"></i></div>
+                        </div>
+                        <div class="k-card-bd">
+                            <div class="k-card-dt">
+                                <div class="k-card-row"><span class="k-card-lbl">Type</span><span
+                                        class="k-card-val">{{ $category->type->value }}</span></div>
+                                <div class="k-card-row"><span class="k-card-lbl">Sub Category</span><span
+                                        class="k-card-val">{{ $category->subCategories->count() }}</span></div>
+                            </div>
+                            <div class="k-card-acts">
+                                <a href="{{ route('admin.event-categories.show', $category) }}"
+                                    class="btn btn-light-primary">Detail</a>
+                                <a href="{{ route('admin.event-categories.edit', $category) }}"
+                                    class="btn btn-light-warning">Edit</a>
+                            </div>
+                        </div>
+                    </div>
+                @empty
+                    <div class="text-center text-muted py-10">Belum ada kategori</div>
+                @endforelse
+            </div>
+        </div>
+    </div>
+
+    @push('scripts')
+        <script>
+            flatpickr('#kt_min_birth_date', {
+                dateFormat: 'Y-m-d',
+                maxDate: 'today'
+            });
+            flatpickr('#kt_max_birth_date', {
+                dateFormat: 'Y-m-d',
+                maxDate: 'today'
+            });
+        </script>
+    @endpush
+</x-app-layout>

--- a/resources/views/admin/sub-categories/edit.blade.php
+++ b/resources/views/admin/sub-categories/edit.blade.php
@@ -1,0 +1,72 @@
+<x-app-layout>
+    @section('title', 'Edit Sub-Kategori - ' . $subCategory->name)
+
+    <form action="{{ route('admin.sub-categories.update', $subCategory) }}" method="POST" class="form">
+        @csrf
+        @method('PUT')
+        <div class="card mb-5">
+            <div class="card-header border-0 pt-5">
+                <h3 class="card-title align-items-start flex-column">
+                    <span class="card-label fw-bold text-dark">Edit Sub-Kategori</span>
+                    <span class="text-muted mt-1 fw-semibold fs-7">{{ $subCategory->eventCategory->class_name }}</span>
+                </h3>
+            </div>
+            <div class="card-body py-5">
+                <div class="row g-4">
+                    <div class="col-md-4">
+                        <label class="required form-label">Name</label>
+                        <input type="text" name="name" class="form-control form-control-solid"
+                            value="{{ old('name', $subCategory->name) }}">
+                        @error('name')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-2">
+                        <label class="required form-label">Gender</label>
+                        <select name="gender" class="form-select form-select-solid">
+                            <option value="M" @selected(old('gender', $subCategory->gender->value) === 'M')>M</option>
+                            <option value="F" @selected(old('gender', $subCategory->gender->value) === 'F')>F</option>
+                            <option value="Mixed" @selected(old('gender', $subCategory->gender->value) === 'Mixed')>Mixed</option>
+                        </select>
+                        @error('gender')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-2">
+                        <label class="required form-label">Price</label>
+                        <input type="number" name="price" class="form-control form-control-solid"
+                            value="{{ old('price', $subCategory->price) }}" min="0" step="0.01"
+                            {{ $subCategory->canEditPrice() ? '' : 'disabled' }}>
+                        @if (!$subCategory->canEditPrice())
+                            <input type="hidden" name="price" value="{{ $subCategory->price }}">
+                        @endif
+                        @error('price')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-2">
+                        <label class="required form-label">Min Participants</label>
+                        <input type="number" name="min_participants" class="form-control form-control-solid"
+                            value="{{ old('min_participants', $subCategory->min_participants) }}" min="1">
+                        @error('min_participants')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-2">
+                        <label class="required form-label">Max Participants</label>
+                        <input type="number" name="max_participants" class="form-control form-control-solid"
+                            value="{{ old('max_participants', $subCategory->max_participants) }}" min="1">
+                        @error('max_participants')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="d-flex justify-content-end">
+            <a href="{{ route('admin.event-categories.show', $subCategory->eventCategory) }}"
+                class="btn btn-light btn-active-light-primary me-2">Batal</a>
+            <button type="submit" class="btn btn-primary">Simpan</button>
+        </div>
+    </form>
+</x-app-layout>

--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -168,19 +168,27 @@
                 @endcan
 
                 {{-- 4. SECTION OPERASIONAL --}}
-                @can('view users')
+                @canany(['view users', 'manage settings'])
                     <div class="menu-item">
                         <div class="menu-content pt-8 pb-2">
                             <span class="menu-section text-muted text-uppercase fs-8 ls-1">Operasional</span>
                         </div>
                     </div>
                     <div class="menu-item">
-                        <a class="menu-link" href="#">
+                        <a class="menu-link {{ request()->routeIs('admin.events.*') || request()->routeIs('admin.event-categories.*') || request()->routeIs('admin.sub-categories.*') ? 'active' : '' }}"
+                            href="{{ route('admin.events.index') }}">
+                            <span class="menu-icon"><i class="bi bi-calendar-event fs-3"></i></span>
+                            <span class="menu-title">Event Management</span>
+                        </a>
+                    </div>
+                    <div class="menu-item">
+                        <a class="menu-link {{ request()->routeIs('reports.*') ? 'active' : '' }}"
+                            href="{{ route('reports.index') }}">
                             <span class="menu-icon"><i class="bi bi-file-earmark fs-3"></i></span>
                             <span class="menu-title">Laporan</span>
                         </a>
                     </div>
-                @endcan
+                @endcanany
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,9 @@ use App\Modules\AuthManagement\Controllers\UserController;
 use App\Modules\AuthManagement\Controllers\RoleController;
 use App\Modules\AuthManagement\Controllers\PermissionController;
 use App\Http\Controllers\ReportController;
+use App\Http\Controllers\Admin\EventController;
+use App\Http\Controllers\Admin\EventCategoryController;
+use App\Http\Controllers\Admin\SubCategoryController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -51,6 +54,22 @@ Route::middleware('auth')->group(function () {
     });
     Route::middleware(['permission:delete participants'])->group(function () {
         Route::delete('participants/{participant}', [ParticipantController::class, 'destroy'])->name('participants.destroy');
+    });
+
+    Route::middleware(['role:super-admin'])->prefix('admin')->name('admin.')->group(function () {
+        Route::resource('events', EventController::class);
+        Route::patch('events/{event}/transition', [EventController::class, 'transition'])->name('events.transition');
+
+        Route::post('events/{event}/categories', [EventCategoryController::class, 'store'])->name('events.categories.store');
+        Route::get('event-categories/{eventCategory}', [EventCategoryController::class, 'show'])->name('event-categories.show');
+        Route::get('event-categories/{eventCategory}/edit', [EventCategoryController::class, 'edit'])->name('event-categories.edit');
+        Route::put('event-categories/{eventCategory}', [EventCategoryController::class, 'update'])->name('event-categories.update');
+        Route::delete('event-categories/{eventCategory}', [EventCategoryController::class, 'destroy'])->name('event-categories.destroy');
+        Route::post('event-categories/{eventCategory}/sub-categories', [SubCategoryController::class, 'store'])->name('event-categories.sub-categories.store');
+
+        Route::get('sub-categories/{subCategory}/edit', [SubCategoryController::class, 'edit'])->name('sub-categories.edit');
+        Route::put('sub-categories/{subCategory}', [SubCategoryController::class, 'update'])->name('sub-categories.update');
+        Route::delete('sub-categories/{subCategory}', [SubCategoryController::class, 'destroy'])->name('sub-categories.destroy');
     });
 
     // Laporan (Reports) - simple index page


### PR DESCRIPTION
Implement admin event management UI for PHASE 3, including:
- Event list/create/edit/detail/delete
- Event status transition buttons with confirmation
- Category CRUD on event detail
- Sub-category CRUD on category detail
- Responsive mobile cards using the participants list pattern

Validation:
- php artisan route:list --name=admin.events
- php artisan route:list --name=admin.event-categories
- php artisan route:list --name=admin.sub-categories
- php artisan view:cache