### PR TITLE
feat: multi-team beregu registration engine (#37)

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,22 @@
+## Design Context
+
+### Users
+- **Primary**: Pelatih/Kontingen — mendaftarkan atlet ke kategori pertandingan karate dari laptop/kantor
+- **Secondary**: Panitia — bisa melihat halaman pendaftaran untuk monitoring
+- **Context**: Admin/management portal, digunakan di lingkungan kantor/organisasi olahraga
+
+### Brand Personality
+Clean, modern, sporty, professional — aplikasi manajemen event olahraga yang serius tapi tidak kaku
+
+### Aesthetic Direction
+- **Theme**: Light mode (admin portal yang digunakan di jam kerja/kantor)
+- **UI Framework**: Metronic v8.3.0 (Bootstrap 5) — gunakan komponen dan warna bawaan Metronic
+- **Font**: Poppins (sudah loaded via CDN)
+- **Tone**: Rapi, cepat dipahami, fungsional — clean & professional dengan sentuhan sporty
+
+### Design Principles
+1. **Clarity first** — pelatih harus bisa mendaftarkan atlet dengan cepat tanpa bingung
+2. **Follow Metronic conventions** — gunakan komponen, spacing, dan warna bawaan Metronic secara konsisten
+3. **Visual rhythm through spacing** — variasi spacing untuk hierarchy, bukan spacing yang sama di mana-mana
+4. **Progressive disclosure** — stepper wizard yang jelas, informasi relevan per step
+5. **No unnecessary decoration** — fungsionalitas > dekorasi, tapi tetap terlihat polished

--- a/app/Http/Requests/Admin/SubCategoryRequest.php
+++ b/app/Http/Requests/Admin/SubCategoryRequest.php
@@ -12,10 +12,12 @@ class SubCategoryRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
+            'category_type' => ['required', Rule::in(['individu', 'beregu'])],
             'gender' => ['required', Rule::enum(SubCategoryGender::class)],
             'price' => ['required', 'numeric', 'min:0'],
             'min_participants' => ['required', 'integer', 'min:1'],
             'max_participants' => ['required', 'integer', 'gte:min_participants'],
+            'max_teams' => ['required', 'integer', 'min:1', 'max:10'],
         ];
     }
 }

--- a/app/Livewire/AthleteSelectionForm.php
+++ b/app/Livewire/AthleteSelectionForm.php
@@ -44,6 +44,10 @@ class AthleteSelectionForm extends Component
 
     public bool $showSavedIndicator = false;
 
+    // Untuk mode beregu
+    public array $teams = [];           // Array of team data: [{id, name, number, memberIds}]
+    public ?int $activeTeamId = null;   // Tim yang sedang diedit
+
     // ===== Lifecycle =====
 
     public function mount(int $event, int $category, int $sub_category): void
@@ -79,6 +83,11 @@ class AthleteSelectionForm extends Component
             ->where('sub_category_id', $this->subCategoryId)
             ->pluck('participant_id')
             ->toArray();
+
+        // Jika beregu, load tim-tim yang sudah dibuat
+        if ($subCategory->isTeam()) {
+            $this->loadTeams();
+        }
     }
 
     // ===== Computed Properties =====
@@ -93,6 +102,7 @@ class AthleteSelectionForm extends Component
     public function eligibleAthletes()
     {
         return Participant::eligibleFor($this->subCategory)
+            ->with(['registrations.subCategory', 'draftItems.subCategory'])
             ->when($this->search !== '', fn($q) => $q->where('name', 'like', "%{$this->search}%"))
             ->orderBy('name')
             ->get();
@@ -104,6 +114,7 @@ class AthleteSelectionForm extends Component
         // Ambil SEMUA atlet milik kontingen
         $allAthletes = Participant::athletes()
             ->where('contingent_id', auth()->user()->contingent->id)
+            ->with(['registrations.subCategory', 'draftItems.subCategory'])
             ->get();
 
         // Filter yang TIDAK eligible + tentukan alasan
@@ -121,6 +132,156 @@ class AthleteSelectionForm extends Component
     public function toggleIneligible(): void
     {
         $this->showIneligible = !$this->showIneligible;
+    }
+
+    public function createTeam(): void
+    {
+        $sub = $this->subCategory();
+        if (count($this->teams) >= $sub->max_teams) {
+            $this->errorMessage = "Maksimal {$sub->max_teams} tim untuk sub-kategori ini.";
+            return;
+        }
+
+        $contingent = auth()->user()->contingent;
+        $teamNumber = count($this->teams) + 1;
+
+        $team = \App\Models\TeamGroup::create([
+            'contingent_id' => $contingent->id,
+            'sub_category_id' => $this->subCategoryId,
+            'team_name' => "Tim " . chr(64 + $teamNumber), // Tim A, Tim B, dst
+            'team_number' => $teamNumber,
+        ]);
+
+        $this->loadTeams();
+        $this->activeTeamId = $team->id;
+        $this->showSavedIndicator = true;
+    }
+
+    public function deleteTeam(int $teamGroupId): void
+    {
+        $team = \App\Models\TeamGroup::where('id', $teamGroupId)
+            ->where('contingent_id', auth()->user()->contingent->id)
+            ->first();
+
+        if ($team) {
+            // Hapus anggota tim dari draf
+            RegistrationDraftItem::where('team_group_id', $team->id)->delete();
+            $team->delete();
+
+            if ($this->activeTeamId === $teamGroupId) {
+                $this->activeTeamId = null;
+            }
+
+            $this->loadTeams();
+            $this->showSavedIndicator = true;
+        }
+    }
+
+    public function selectTeam(int $teamGroupId): void
+    {
+        if ($this->activeTeamId === $teamGroupId) {
+            $this->activeTeamId = null; // Toggle off if already selected
+            return;
+        }
+        $this->activeTeamId = $teamGroupId;
+    }
+
+    public function toggleTeamMember(int $athleteId): void
+    {
+        if (!$this->activeTeamId) {
+            $this->errorMessage = 'Pilih tim terlebih dahulu.';
+            return;
+        }
+
+        $this->errorMessage = '';
+        $this->showSavedIndicator = false;
+
+        $contingent = auth()->user()->contingent;
+        $draft = RegistrationDraft::where('contingent_id', $contingent->id)
+            ->where('event_id', $this->eventId)
+            ->where('status', 'draft')
+            ->first();
+
+        if (!$draft) return;
+
+        $registrationService = app(RegistrationService::class);
+        if (!$registrationService->isRegistrationOpen($this->subCategory->eventCategory->event)) {
+            $this->errorMessage = 'Pendaftaran event sudah ditutup.';
+            return;
+        }
+
+        // Cek apakah sudah ada di tim ini
+        $existing = RegistrationDraftItem::where('registration_draft_id', $draft->id)
+            ->where('sub_category_id', $this->subCategoryId)
+            ->where('participant_id', $athleteId)
+            ->where('team_group_id', $this->activeTeamId)
+            ->first();
+
+        if ($existing) {
+            $existing->delete();
+        } else {
+            // Cek apakah sudah ada di tim LAIN pada sub-kategori yang sama
+            $inOtherTeam = RegistrationDraftItem::where('registration_draft_id', $draft->id)
+                ->where('sub_category_id', $this->subCategoryId)
+                ->where('participant_id', $athleteId)
+                ->exists();
+
+            if ($inOtherTeam) {
+                $this->errorMessage = 'Atlet sudah terdaftar di tim lain pada kategori ini.';
+                return;
+            }
+
+            // Cek kuota anggota tim
+            $currentMemberCount = RegistrationDraftItem::where('team_group_id', $this->activeTeamId)->count();
+            if ($currentMemberCount >= $this->subCategory->max_participants) {
+                $this->errorMessage = "Tim sudah penuh (maksimal {$this->subCategory->max_participants} atlet).";
+                return;
+            }
+
+            // Cek eligibility
+            $isEligible = Participant::eligibleFor($this->subCategory)->where('participants.id', $athleteId)->exists();
+            if (!$isEligible) {
+                $this->errorMessage = 'Atlet tidak memenuhi syarat untuk kategori ini.';
+                return;
+            }
+
+            RegistrationDraftItem::create([
+                'registration_draft_id' => $draft->id,
+                'participant_id' => $athleteId,
+                'sub_category_id' => $this->subCategoryId,
+                'team_group_id' => $this->activeTeamId,
+            ]);
+        }
+
+        $this->loadTeams();
+        $this->showSavedIndicator = true;
+    }
+
+    public function loadTeams(): void
+    {
+        $contingent = auth()->user()->contingent;
+        $teamGroups = \App\Models\TeamGroup::where('contingent_id', $contingent->id)
+            ->where('sub_category_id', $this->subCategoryId)
+            ->with('draftItems')
+            ->orderBy('team_number')
+            ->get();
+
+        $this->teams = $teamGroups->map(fn($tg) => [
+            'id' => $tg->id,
+            'name' => $tg->team_name,
+            'number' => $tg->team_number,
+            'memberIds' => $tg->draftItems->pluck('participant_id')->toArray(),
+        ])->toArray();
+    }
+
+    public function isAthleteInAnyTeam(int $athleteId): bool
+    {
+        foreach ($this->teams as $team) {
+            if (in_array($athleteId, $team['memberIds'])) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public function updatedSelectedAthleteIds(): void
@@ -191,6 +352,25 @@ class AthleteSelectionForm extends Component
         }
 
         $this->showSavedIndicator = true;
+    }
+
+    public function clearDraft(): void
+    {
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            return;
+        }
+
+        $draft = RegistrationDraft::where('contingent_id', $contingent->id)
+            ->where('event_id', $this->eventId)
+            ->where('status', 'draft')
+            ->first();
+
+        if ($draft) {
+            RegistrationDraftItem::where('registration_draft_id', $draft->id)->delete();
+            $this->selectedAthleteIds = [];
+            $this->showSavedIndicator = true;
+        }
     }
 
 

--- a/app/Livewire/AthleteSelectionForm.php
+++ b/app/Livewire/AthleteSelectionForm.php
@@ -178,7 +178,8 @@ class AthleteSelectionForm extends Component
                 ->delete();
         }
 
-        if (count($eligibleIds) !== count($this->selectedAthleteIds)) {
+        $ineligibleSelection = array_diff($this->selectedAthleteIds, $eligibleIds);
+        if (count($ineligibleSelection) > 0) {
             $this->errorMessage = 'Salah satu atlet yang dipilih tidak memenuhi syarat.';
             $this->selectedAthleteIds = array_values(array_intersect($this->selectedAthleteIds, $eligibleIds));
 

--- a/app/Livewire/AthleteSelectionForm.php
+++ b/app/Livewire/AthleteSelectionForm.php
@@ -5,8 +5,11 @@ namespace App\Livewire;
 use App\Models\Event;
 use App\Models\EventCategory;
 use App\Models\Participant;
+use App\Models\RegistrationDraft;
+use App\Models\RegistrationDraftItem;
 use App\Models\SubCategory;
 use App\Enums\SubCategoryGender;
+use App\Services\RegistrationService;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
@@ -39,8 +42,7 @@ class AthleteSelectionForm extends Component
     // Toggle untuk menampilkan atlet tidak memenuhi syarat
     public bool $showIneligible = false;
 
-    // Confirmation modal state
-    public bool $showConfirmation = false;
+    public bool $showSavedIndicator = false;
 
     // ===== Lifecycle =====
 
@@ -49,6 +51,11 @@ class AthleteSelectionForm extends Component
         $this->eventId = $event;
         $this->categoryId = $category;
         $this->subCategoryId = $sub_category;
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            abort(403, 'Anda belum memiliki data kontingen.');
+        }
 
         // Validasi: pastikan sub_category milik category, dan category milik event
         $subCategory = SubCategory::findOrFail($sub_category);
@@ -61,10 +68,17 @@ class AthleteSelectionForm extends Component
             abort(403, 'Kategori tidak valid untuk event ini.');
         }
 
-        // Pastikan user punya contingent
-        if (!auth()->user()->contingent) {
-            abort(403, 'Anda belum memiliki data kontingen.');
-        }
+        $draft = RegistrationDraft::firstOrCreate([
+            'contingent_id' => $contingent->id,
+            'event_id' => $this->eventId,
+            'status' => 'draft',
+        ]);
+
+        $this->selectedAthleteIds = RegistrationDraftItem::query()
+            ->where('registration_draft_id', $draft->id)
+            ->where('sub_category_id', $this->subCategoryId)
+            ->pluck('participant_id')
+            ->toArray();
     }
 
     // ===== Computed Properties =====
@@ -104,51 +118,81 @@ class AthleteSelectionForm extends Component
 
     // ===== Actions =====
 
-    public function confirmSubmit(): void
-    {
-        $this->errorMessage = '';
-        $this->showConfirmation = true;
-    }
-
-    public function cancelConfirmation(): void
-    {
-        $this->showConfirmation = false;
-    }
-
     public function toggleIneligible(): void
     {
         $this->showIneligible = !$this->showIneligible;
     }
 
-    public function submit(): void
+    public function updatedSelectedAthleteIds(): void
     {
-        // Validasi jumlah atlet yang dipilih (BR-15)
-        $sub = $this->subCategory;
-        $count = count($this->selectedAthleteIds);
+        $this->showSavedIndicator = false;
+        $this->selectedAthleteIds = array_values(array_unique(array_map('intval', $this->selectedAthleteIds)));
+        $draft = RegistrationDraft::where('contingent_id', auth()->user()->contingent->id)
+            ->where('event_id', $this->eventId)
+            ->where('status', 'draft')
+            ->first();
 
-        if ($count < $sub->min_participants || $count > $sub->max_participants) {
-            $this->errorMessage = "{$sub->name} membutuhkan minimal {$sub->min_participants} dan maksimal {$sub->max_participants} atlet.";
+        if (! $draft) {
             return;
         }
 
-        // Validasi ulang: semua atlet yang dipilih harus eligible
-        $eligibleIds = $this->eligibleAthletes->pluck('id')->toArray();
-        foreach ($this->selectedAthleteIds as $id) {
-            if (!in_array($id, $eligibleIds)) {
-                $this->errorMessage = 'Salah satu atlet yang dipilih tidak memenuhi syarat.';
-                return;
-            }
+        $registrationService = app(RegistrationService::class);
+        $event = $this->subCategory->eventCategory->event;
+        if (! $registrationService->isRegistrationOpen($event)) {
+            $this->errorMessage = 'Pendaftaran event sudah ditutup.';
+            return;
         }
 
-        // Simpan ke session atau dispatch event untuk diproses di tahap berikutnya
-        session()->put('registration_draft.event_id', $this->eventId);
-        session()->put('registration_draft.sub_category_id', $this->subCategoryId);
-        session()->put('registration_draft.athlete_ids', $this->selectedAthleteIds);
+        if (count($this->selectedAthleteIds) > $this->subCategory->max_participants) {
+            $this->errorMessage = "{$this->subCategory->name} maksimal {$this->subCategory->max_participants} atlet.";
+            $this->selectedAthleteIds = array_slice($this->selectedAthleteIds, 0, $this->subCategory->max_participants);
+        }
 
-        // Redirect ke halaman konfirmasi/invoice (akan dibuat di Step 4.5)
-        session()->flash('success', 'Atlet berhasil dipilih. Lanjutkan ke konfirmasi.');
-        $this->redirect(route('registration.index'), navigate: true);
+        $existingIds = RegistrationDraftItem::query()
+            ->where('registration_draft_id', $draft->id)
+            ->where('sub_category_id', $this->subCategoryId)
+            ->pluck('participant_id')
+            ->toArray();
+
+        $eligibleIds = $this->eligibleAthletes->pluck('id')->toArray();
+        $toInsert = array_diff($this->selectedAthleteIds, $existingIds);
+        $toInsert = array_values(array_intersect($toInsert, $eligibleIds));
+        $toDelete = array_diff($existingIds, $this->selectedAthleteIds);
+
+        if (count($toInsert) > 0) {
+            $rows = collect($toInsert)->map(fn ($id) => [
+                'registration_draft_id' => $draft->id,
+                'participant_id' => $id,
+                'sub_category_id' => $this->subCategoryId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ])->all();
+            RegistrationDraftItem::insert($rows);
+        }
+
+        if (count($toDelete) > 0) {
+            RegistrationDraftItem::query()
+                ->where('registration_draft_id', $draft->id)
+                ->where('sub_category_id', $this->subCategoryId)
+                ->whereIn('participant_id', $toDelete)
+                ->delete();
+        }
+
+        if (count($eligibleIds) !== count($this->selectedAthleteIds)) {
+            $this->errorMessage = 'Salah satu atlet yang dipilih tidak memenuhi syarat.';
+            $this->selectedAthleteIds = array_values(array_intersect($this->selectedAthleteIds, $eligibleIds));
+
+            RegistrationDraftItem::query()
+                ->where('registration_draft_id', $draft->id)
+                ->where('sub_category_id', $this->subCategoryId)
+                ->whereNotIn('participant_id', $this->selectedAthleteIds)
+                ->delete();
+        }
+
+        $this->showSavedIndicator = true;
     }
+
+
 
     // ===== Helper Methods (Private) =====
 

--- a/app/Livewire/CoachSelectionForm.php
+++ b/app/Livewire/CoachSelectionForm.php
@@ -18,6 +18,8 @@ class CoachSelectionForm extends Component
     public ?int $selectedEventId = null;
     public array $selectedCoachIds = [];
     public string $errorMessage = '';
+    public string $search = '';
+    public bool $showSavedIndicator = false;
 
     // Lifecycle
     public function mount(): void
@@ -32,6 +34,7 @@ class CoachSelectionForm extends Component
     public function updatedSelectedEventId(string|int|null $value): void
     {
         $this->errorMessage = '';
+        $this->showSavedIndicator = false;
 
         // Handle empty/invalid values
         if (empty($value) || !is_numeric($value)) {
@@ -70,6 +73,7 @@ class CoachSelectionForm extends Component
     public function updatedSelectedCoachIds(): void
     {
         $this->errorMessage = '';
+        $this->showSavedIndicator = false;
         $this->selectedCoachIds = array_values(array_unique(array_map('intval', $this->selectedCoachIds)));
 
         if (! $this->selectedEventId) {
@@ -90,76 +94,61 @@ class CoachSelectionForm extends Component
             return;
         }
 
-        // Get confirmed coach IDs
+        // Get draft
+        $draft = \App\Models\RegistrationDraft::firstOrCreate([
+            'contingent_id' => $contingent->id,
+            'event_id' => $this->selectedEventId,
+            'status' => 'draft',
+        ]);
+
+        // Get confirmed coach IDs (those already in a verified/pending payment)
         $confirmedCoachIds = $this->getConfirmedCoachIds();
 
-        // Remove confirmed coaches from selection
-        $this->selectedCoachIds = array_values(array_diff($this->selectedCoachIds, $confirmedCoachIds));
-
-        if (count($confirmedCoachIds) > 0) {
+        // If user tries to uncheck a confirmed coach, warn them and re-add it
+        $tryingToRemoveConfirmed = count(array_diff($confirmedCoachIds, $this->selectedCoachIds)) > 0;
+        if ($tryingToRemoveConfirmed) {
             $this->errorMessage = 'Pelatih yang sudah masuk invoice confirmed tidak dapat diubah.';
+            $this->selectedCoachIds = array_values(array_unique(array_merge($this->selectedCoachIds, $confirmedCoachIds)));
         }
 
-        // Validate coach IDs (must belong to contingent)
+        // Validate coach IDs (must belong to contingent and be of type Coach)
         $validCoachIds = $this->coaches()->pluck('id')->toArray();
         $this->selectedCoachIds = array_values(array_intersect($this->selectedCoachIds, $validCoachIds));
 
-        // Get currently registered coaches
-        $registeredCoachIds = $this->getRegisteredCoachIds();
+        // Get current coach IDs in draft
+        $draftCoachIds = \App\Models\RegistrationDraftItem::query()
+            ->where('registration_draft_id', $draft->id)
+            ->whereNull('sub_category_id')
+            ->pluck('participant_id')
+            ->toArray();
 
-        // Coaches to insert (newly selected)
-        $toInsert = array_diff($this->selectedCoachIds, $registeredCoachIds);
+        // Coaches to insert into draft
+        $toInsert = array_diff($this->selectedCoachIds, $draftCoachIds);
+        $toInsert = array_diff($toInsert, $confirmedCoachIds); // Don't re-insert confirmed ones
 
-        // Coaches to delete (unselected)
-        $toDelete = array_diff($registeredCoachIds, $this->selectedCoachIds);
+        // Coaches to delete from draft
+        $toDelete = array_diff($draftCoachIds, $this->selectedCoachIds);
 
-        // Insert new registrations - need to find or create payment first
-        $payment = \App\Models\Payment::firstOrCreate(
-            [
-                'contingent_id' => $contingent->id,
-                'event_id' => $this->selectedEventId,
-                'status' => \App\Enums\PaymentStatus::Pending,
-            ],
-            [
-                'total_amount' => 0,
-                'transfer_proof' => null,
-                'verified_at' => null,
-                'verified_by' => null,
-                'rejection_reason' => null,
-            ]
-        );
-
-        foreach ($toInsert as $coachId) {
-            // Check if already exists to prevent duplicates
-            $exists = \App\Models\Registration::query()
-                ->where('participant_id', $coachId)
-                ->where('payment_id', $payment->id)
-                ->whereNull('sub_category_id')
-                ->exists();
-
-            if (! $exists) {
-                \App\Models\Registration::create([
-                    'participant_id' => $coachId,
-                    'payment_id' => $payment->id,
-                    'sub_category_id' => null,
-                    'status_berkas' => \App\Enums\RegistrationStatus::Unsubmitted,
-                    'verified_at' => null,
-                    'verified_by' => null,
-                ]);
-            }
+        if (count($toInsert) > 0) {
+            $rows = collect($toInsert)->map(fn ($id) => [
+                'registration_draft_id' => $draft->id,
+                'participant_id' => $id,
+                'sub_category_id' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ])->all();
+            \App\Models\RegistrationDraftItem::insert($rows);
         }
 
-        // Delete unselected registrations
         if (count($toDelete) > 0) {
-            \App\Models\Registration::query()
-                ->whereHas('participant', function ($query) use ($contingent) {
-                    $query->where('contingent_id', $contingent->id);
-                })
+            \App\Models\RegistrationDraftItem::query()
+                ->where('registration_draft_id', $draft->id)
                 ->whereNull('sub_category_id')
-                ->where('payment_id', $payment->id)
                 ->whereIn('participant_id', $toDelete)
                 ->delete();
         }
+
+        $this->showSavedIndicator = true;
     }
 
     // Computed Properties
@@ -168,6 +157,12 @@ class CoachSelectionForm extends Component
     {
         $registrationService = app(RegistrationService::class);
         return $registrationService->getOpenEvents();
+    }
+
+    #[Computed]
+    public function selectedEvent(): ?Event
+    {
+        return $this->selectedEventId ? Event::find($this->selectedEventId) : null;
     }
 
     #[Computed]
@@ -180,6 +175,7 @@ class CoachSelectionForm extends Component
 
         return Participant::coaches()
             ->where('contingent_id', $contingent->id)
+            ->when($this->search !== '', fn($q) => $q->where('name', 'like', "%{$this->search}%"))
             ->orderBy('name')
             ->get();
     }
@@ -214,18 +210,30 @@ class CoachSelectionForm extends Component
             return [];
         }
 
-        return Registration::query()
+        // Combine IDs from Draft and existing active Registrations
+        $draftIds = \App\Models\RegistrationDraftItem::query()
+            ->whereHas('draft', function ($query) use ($contingent) {
+                $query->where('contingent_id', $contingent->id)
+                    ->where('event_id', $this->selectedEventId)
+                    ->where('status', 'draft');
+            })
+            ->whereNull('sub_category_id')
+            ->pluck('participant_id')
+            ->toArray();
+
+        $activeIds = Registration::query()
             ->whereHas('participant', function ($query) use ($contingent) {
                 $query->where('contingent_id', $contingent->id);
             })
             ->whereNull('sub_category_id')
             ->whereHas('payment', function ($query) {
                 $query->where('event_id', $this->selectedEventId)
-                    ->where('status', '!=', 'cancelled');
+                    ->where('status', '!=', \App\Enums\PaymentStatus::Cancelled);
             })
             ->pluck('participant_id')
-            ->unique()
             ->toArray();
+
+        return array_values(array_unique(array_merge($draftIds, $activeIds)));
     }
 
     private function getConfirmedCoachIds(): array
@@ -246,10 +254,12 @@ class CoachSelectionForm extends Component
             ->whereNull('sub_category_id')
             ->whereHas('payment', function ($query) {
                 $query->where('event_id', $this->selectedEventId)
-                    ->where('status', 'confirmed');
+                    ->where('status', '!=', \App\Enums\PaymentStatus::Cancelled);
             })
             ->pluck('participant_id')
             ->unique()
             ->toArray();
     }
+
+
 }

--- a/app/Livewire/CoachSelectionForm.php
+++ b/app/Livewire/CoachSelectionForm.php
@@ -118,7 +118,7 @@ class CoachSelectionForm extends Component
             [
                 'contingent_id' => $contingent->id,
                 'event_id' => $this->selectedEventId,
-                'status' => 'draft',
+                'status' => \App\Enums\PaymentStatus::Pending,
             ],
             [
                 'total_amount' => 0,
@@ -142,7 +142,7 @@ class CoachSelectionForm extends Component
                     'participant_id' => $coachId,
                     'payment_id' => $payment->id,
                     'sub_category_id' => null,
-                    'status_berkas' => 'pending',
+                    'status_berkas' => \App\Enums\RegistrationStatus::Unsubmitted,
                     'verified_at' => null,
                     'verified_by' => null,
                 ]);

--- a/app/Livewire/CoachSelectionForm.php
+++ b/app/Livewire/CoachSelectionForm.php
@@ -29,10 +29,18 @@ class CoachSelectionForm extends Component
     }
 
     // Actions
-    public function updatedSelectedEventId(int $value): void
+    public function updatedSelectedEventId(string|int|null $value): void
     {
         $this->errorMessage = '';
-        $this->selectedEventId = $value;
+
+        // Handle empty/invalid values
+        if (empty($value) || !is_numeric($value)) {
+            $this->selectedEventId = null;
+            $this->selectedCoachIds = [];
+            return;
+        }
+
+        $this->selectedEventId = (int) $value;
 
         if (! $this->selectedEventId) {
             $this->selectedCoachIds = [];
@@ -105,30 +113,51 @@ class CoachSelectionForm extends Component
         // Coaches to delete (unselected)
         $toDelete = array_diff($registeredCoachIds, $this->selectedCoachIds);
 
-        // Insert new registrations
-        foreach ($toInsert as $coachId) {
-            Registration::create([
-                'participant_id' => $coachId,
-                'payment_id' => null,
-                'sub_category_id' => null,
-                'status_berkas' => 'pending',
+        // Insert new registrations - need to find or create payment first
+        $payment = \App\Models\Payment::firstOrCreate(
+            [
+                'contingent_id' => $contingent->id,
+                'event_id' => $this->selectedEventId,
+                'status' => 'draft',
+            ],
+            [
+                'total_amount' => 0,
+                'transfer_proof' => null,
                 'verified_at' => null,
                 'verified_by' => null,
-            ]);
+                'rejection_reason' => null,
+            ]
+        );
+
+        foreach ($toInsert as $coachId) {
+            // Check if already exists to prevent duplicates
+            $exists = \App\Models\Registration::query()
+                ->where('participant_id', $coachId)
+                ->where('payment_id', $payment->id)
+                ->whereNull('sub_category_id')
+                ->exists();
+
+            if (! $exists) {
+                \App\Models\Registration::create([
+                    'participant_id' => $coachId,
+                    'payment_id' => $payment->id,
+                    'sub_category_id' => null,
+                    'status_berkas' => 'pending',
+                    'verified_at' => null,
+                    'verified_by' => null,
+                ]);
+            }
         }
 
         // Delete unselected registrations
         if (count($toDelete) > 0) {
-            Registration::query()
+            \App\Models\Registration::query()
                 ->whereHas('participant', function ($query) use ($contingent) {
                     $query->where('contingent_id', $contingent->id);
                 })
                 ->whereNull('sub_category_id')
-                ->whereHas('payment', function ($query) {
-                    $query->where('event_id', $this->selectedEventId);
-                })
+                ->where('payment_id', $payment->id)
                 ->whereIn('participant_id', $toDelete)
-                ->whereNull('payment_id') // Only delete if not linked to payment
                 ->delete();
         }
     }

--- a/app/Livewire/CoachSelectionForm.php
+++ b/app/Livewire/CoachSelectionForm.php
@@ -151,6 +151,29 @@ class CoachSelectionForm extends Component
         $this->showSavedIndicator = true;
     }
 
+    public function clearDraft(): void
+    {
+        if (! $this->selectedEventId) {
+            return;
+        }
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            return;
+        }
+
+        $draft = \App\Models\RegistrationDraft::where('contingent_id', $contingent->id)
+            ->where('event_id', $this->selectedEventId)
+            ->where('status', 'draft')
+            ->first();
+
+        if ($draft) {
+            \App\Models\RegistrationDraftItem::where('registration_draft_id', $draft->id)->delete();
+            $this->selectedCoachIds = $this->getConfirmedCoachIds(); // Keep confirmed ones
+            $this->showSavedIndicator = true;
+        }
+    }
+
     // Computed Properties
     #[Computed]
     public function events(): Collection

--- a/app/Livewire/CoachSelectionForm.php
+++ b/app/Livewire/CoachSelectionForm.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Event;
+use App\Models\Participant;
+use App\Models\Registration;
+use App\Services\RegistrationService;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class CoachSelectionForm extends Component
+{
+    // Properties
+    public ?int $selectedEventId = null;
+    public array $selectedCoachIds = [];
+    public string $errorMessage = '';
+
+    // Lifecycle
+    public function mount(): void
+    {
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            abort(403, 'Anda belum memiliki data kontingen.');
+        }
+    }
+
+    // Actions
+    public function updatedSelectedEventId(int $value): void
+    {
+        $this->errorMessage = '';
+        $this->selectedEventId = $value;
+
+        if (! $this->selectedEventId) {
+            $this->selectedCoachIds = [];
+            return;
+        }
+
+        $registrationService = app(RegistrationService::class);
+        $event = Event::find($this->selectedEventId);
+
+        if (! $event || ! $registrationService->isRegistrationOpen($event)) {
+            $this->errorMessage = 'Event tidak valid atau pendaftaran sudah ditutup.';
+            $this->selectedEventId = null;
+            $this->selectedCoachIds = [];
+            return;
+        }
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            $this->errorMessage = 'Anda belum memiliki data kontingen.';
+            return;
+        }
+
+        // Load selected coaches for this event
+        $this->selectedCoachIds = $this->getRegisteredCoachIds();
+    }
+
+    public function updatedSelectedCoachIds(): void
+    {
+        $this->errorMessage = '';
+        $this->selectedCoachIds = array_values(array_unique(array_map('intval', $this->selectedCoachIds)));
+
+        if (! $this->selectedEventId) {
+            return;
+        }
+
+        $registrationService = app(RegistrationService::class);
+        $event = Event::find($this->selectedEventId);
+
+        if (! $event || ! $registrationService->isRegistrationOpen($event)) {
+            $this->errorMessage = 'Pendaftaran event sudah ditutup.';
+            $this->selectedCoachIds = $this->getRegisteredCoachIds();
+            return;
+        }
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            return;
+        }
+
+        // Get confirmed coach IDs
+        $confirmedCoachIds = $this->getConfirmedCoachIds();
+
+        // Remove confirmed coaches from selection
+        $this->selectedCoachIds = array_values(array_diff($this->selectedCoachIds, $confirmedCoachIds));
+
+        if (count($confirmedCoachIds) > 0) {
+            $this->errorMessage = 'Pelatih yang sudah masuk invoice confirmed tidak dapat diubah.';
+        }
+
+        // Validate coach IDs (must belong to contingent)
+        $validCoachIds = $this->coaches()->pluck('id')->toArray();
+        $this->selectedCoachIds = array_values(array_intersect($this->selectedCoachIds, $validCoachIds));
+
+        // Get currently registered coaches
+        $registeredCoachIds = $this->getRegisteredCoachIds();
+
+        // Coaches to insert (newly selected)
+        $toInsert = array_diff($this->selectedCoachIds, $registeredCoachIds);
+
+        // Coaches to delete (unselected)
+        $toDelete = array_diff($registeredCoachIds, $this->selectedCoachIds);
+
+        // Insert new registrations
+        foreach ($toInsert as $coachId) {
+            Registration::create([
+                'participant_id' => $coachId,
+                'payment_id' => null,
+                'sub_category_id' => null,
+                'status_berkas' => 'pending',
+                'verified_at' => null,
+                'verified_by' => null,
+            ]);
+        }
+
+        // Delete unselected registrations
+        if (count($toDelete) > 0) {
+            Registration::query()
+                ->whereHas('participant', function ($query) use ($contingent) {
+                    $query->where('contingent_id', $contingent->id);
+                })
+                ->whereNull('sub_category_id')
+                ->whereHas('payment', function ($query) {
+                    $query->where('event_id', $this->selectedEventId);
+                })
+                ->whereIn('participant_id', $toDelete)
+                ->whereNull('payment_id') // Only delete if not linked to payment
+                ->delete();
+        }
+    }
+
+    // Computed Properties
+    #[Computed]
+    public function events(): Collection
+    {
+        $registrationService = app(RegistrationService::class);
+        return $registrationService->getOpenEvents();
+    }
+
+    #[Computed]
+    public function coaches(): Collection
+    {
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            return collect();
+        }
+
+        return Participant::coaches()
+            ->where('contingent_id', $contingent->id)
+            ->orderBy('name')
+            ->get();
+    }
+
+    #[Computed]
+    public function registeredCoachIds(): array
+    {
+        return $this->getRegisteredCoachIds();
+    }
+
+    // Render
+    public function render()
+    {
+        return view('livewire.coach-selection-form');
+    }
+
+    // Private Methods
+    private function getRegisteredCoachIds(): array
+    {
+        if (! $this->selectedEventId) {
+            return [];
+        }
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            return [];
+        }
+
+        return Registration::query()
+            ->whereHas('participant', function ($query) use ($contingent) {
+                $query->where('contingent_id', $contingent->id);
+            })
+            ->whereNull('sub_category_id')
+            ->whereHas('payment', function ($query) {
+                $query->where('event_id', $this->selectedEventId)
+                    ->where('status', '!=', 'cancelled');
+            })
+            ->pluck('participant_id')
+            ->unique()
+            ->toArray();
+    }
+
+    private function getConfirmedCoachIds(): array
+    {
+        if (! $this->selectedEventId) {
+            return [];
+        }
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            return [];
+        }
+
+        return Registration::query()
+            ->whereHas('participant', function ($query) use ($contingent) {
+                $query->where('contingent_id', $contingent->id);
+            })
+            ->whereNull('sub_category_id')
+            ->whereHas('payment', function ($query) {
+                $query->where('event_id', $this->selectedEventId)
+                    ->where('status', 'confirmed');
+            })
+            ->pluck('participant_id')
+            ->unique()
+            ->toArray();
+    }
+}

--- a/app/Livewire/CoachSelectionForm.php
+++ b/app/Livewire/CoachSelectionForm.php
@@ -190,6 +190,12 @@ class CoachSelectionForm extends Component
         return $this->getRegisteredCoachIds();
     }
 
+    #[Computed]
+    public function confirmedCoachIds(): array
+    {
+        return $this->getConfirmedCoachIds();
+    }
+
     // Render
     public function render()
     {

--- a/app/Livewire/EventRegistrationInvoice.php
+++ b/app/Livewire/EventRegistrationInvoice.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Enums\PaymentStatus;
+use App\Enums\RegistrationStatus;
+use App\Models\Event;
+use App\Models\Participant;
+use App\Models\Payment;
+use App\Models\Registration;
+use App\Models\RegistrationDraft;
+use App\Models\RegistrationDraftItem;
+use App\Models\SubCategory;
+use App\Services\RegistrationService;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class EventRegistrationInvoice extends Component
+{
+    #[Locked]
+    public int $eventId;
+
+    #[Locked]
+    public ?int $subCategoryId = null;
+
+    public array $selectedSubCategories = [];
+    public array $selectedCoachIds = [];
+    public string $errorMessage = '';
+    public bool $showConfirmation = false;
+    public ?int $draftId = null;
+
+    public function mount(int $event): void
+    {
+        $this->eventId = $event;
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            abort(403, 'Anda belum memiliki data kontingen.');
+        }
+
+        $draft = RegistrationDraft::where('event_id', $this->eventId)
+            ->where('contingent_id', $contingent->id)
+            ->where('status', 'draft')
+            ->first();
+
+        if (! $draft) {
+            session()->flash('error', 'Draft pendaftaran tidak ditemukan untuk event ini.');
+            $this->redirect(route('registration.index'), navigate: true);
+            return;
+        }
+
+        $this->draftId = $draft->id;
+
+        $athleteItems = RegistrationDraftItem::query()
+            ->where('registration_draft_id', $draft->id)
+            ->whereNotNull('sub_category_id')
+            ->get();
+
+        foreach ($athleteItems as $item) {
+            $this->selectedSubCategories[$item->sub_category_id][] = $item->participant_id;
+        }
+
+        $this->selectedCoachIds = RegistrationDraftItem::query()
+            ->where('registration_draft_id', $draft->id)
+            ->whereNull('sub_category_id')
+            ->pluck('participant_id')
+            ->unique()
+            ->values()
+            ->toArray();
+
+        if (count($this->selectedSubCategories) === 0 && count($this->selectedCoachIds) === 0) {
+            session()->flash('error', 'Draft pendaftaran masih kosong. Silakan pilih atlet atau pelatih terlebih dahulu.');
+            $this->redirect(route('registration.index'), navigate: true);
+            return;
+        }
+
+        if (count($this->selectedSubCategories) === 0 && count($this->selectedCoachIds) === 0) {
+            session()->flash('error', 'Draft pendaftaran masih kosong. Silakan pilih atlet atau pelatih terlebih dahulu.');
+            $this->redirect(route('registration.index'), navigate: true);
+            return;
+        }
+    }
+
+    #[Computed]
+    public function event(): Event
+    {
+        return Event::findOrFail($this->eventId);
+    }
+
+    #[Computed]
+    public function subCategory(): ?SubCategory
+    {
+        return null;
+    }
+
+    #[Computed]
+    public function athletes(): Collection
+    {
+        return collect();
+    }
+
+    #[Computed]
+    public function coaches(): Collection
+    {
+        if (count($this->selectedCoachIds) === 0) {
+            return collect();
+        }
+
+        return Participant::coaches()
+            ->where('contingent_id', auth()->user()->contingent->id)
+            ->whereIn('id', $this->selectedCoachIds)
+            ->orderBy('name')
+            ->get();
+    }
+
+    #[Computed]
+    public function athleteSelections(): Collection
+    {
+        if (count($this->selectedSubCategories) === 0) {
+            return collect();
+        }
+
+        $subCategories = SubCategory::whereIn('id', array_keys($this->selectedSubCategories))
+            ->with('eventCategory')
+            ->get()
+            ->keyBy('id');
+
+        $allAthleteIds = collect($this->selectedSubCategories)->flatten()->unique()->values()->all();
+        $athletes = Participant::athletes()
+            ->where('contingent_id', auth()->user()->contingent->id)
+            ->whereIn('id', $allAthleteIds)
+            ->orderBy('name')
+            ->get()
+            ->keyBy('id');
+
+        return collect($this->selectedSubCategories)
+            ->map(function (array $athleteIds, int $subCategoryId) use ($subCategories, $athletes) {
+                $subCategory = $subCategories->get($subCategoryId);
+                if (! $subCategory) {
+                    return null;
+                }
+
+                $list = collect($athleteIds)
+                    ->map(fn ($athleteId) => $athletes->get($athleteId))
+                    ->filter()
+                    ->values();
+
+                return [
+                    'subCategory' => $subCategory,
+                    'athletes' => $list,
+                ];
+            })
+            ->filter()
+            ->values();
+    }
+
+    #[Computed]
+    public function totalAthleteFee(): float
+    {
+        if ($this->athleteSelections->count() === 0) {
+            return 0;
+        }
+
+        if ($this->athleteSelections->count() > 0) {
+            return $this->athleteSelections->sum(function (array $selection) {
+                return (float) $selection['subCategory']->price * $selection['athletes']->count();
+            });
+        }
+
+        return 0;
+    }
+
+    #[Computed]
+    public function totalCoachFee(): float
+    {
+        if ($this->coaches->count() === 0) {
+            return 0;
+        }
+
+        return (float) $this->event->coach_fee * $this->coaches->count();
+    }
+
+    #[Computed]
+    public function totalAmount(): float
+    {
+        return (float) $this->event->event_fee + $this->totalAthleteFee + $this->totalCoachFee;
+    }
+
+    public function confirmSubmit(): void
+    {
+        $this->errorMessage = '';
+        $this->showConfirmation = true;
+    }
+
+    public function cancelConfirmation(): void
+    {
+        $this->showConfirmation = false;
+    }
+
+    public function submit(RegistrationService $registrationService): void
+    {
+        $this->errorMessage = '';
+        $event = $this->event;
+
+        if (! $registrationService->isRegistrationOpen($event)) {
+            $this->errorMessage = 'Pendaftaran event sudah ditutup.';
+            return;
+        }
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            $this->errorMessage = 'Anda belum memiliki data kontingen.';
+            return;
+        }
+
+        if ($registrationService->hasExistingPayment($contingent->id, $event->id)) {
+            $this->errorMessage = 'Anda sudah memiliki invoice aktif untuk event ini.';
+            return;
+        }
+
+        if (count($this->selectedSubCategories) > 0) {
+            foreach ($this->selectedSubCategories as $subCategoryId => $athleteIds) {
+                $subCategory = SubCategory::with('eventCategory')->find($subCategoryId);
+                if (! $subCategory || $subCategory->eventCategory->event_id !== $event->id) {
+                    $this->errorMessage = 'Sub-kategori tidak valid untuk event ini.';
+                    return;
+                }
+
+                $athleteCount = count($athleteIds);
+                if ($athleteCount < $subCategory->min_participants || $athleteCount > $subCategory->max_participants) {
+                    $this->errorMessage = 'Jumlah atlet tidak sesuai dengan ketentuan sub-kategori.';
+                    return;
+                }
+
+                $eligibleIds = Participant::eligibleFor($subCategory)
+                    ->whereIn('id', $athleteIds)
+                    ->pluck('id')
+                    ->toArray();
+
+                if (count($eligibleIds) !== $athleteCount) {
+                    $this->errorMessage = 'Terdapat atlet yang tidak memenuhi syarat.';
+                    return;
+                }
+            }
+        }
+
+        $registeredCoachIds = Registration::query()
+            ->whereNull('sub_category_id')
+            ->whereHas('payment', function ($query) use ($event) {
+                $query->where('event_id', $event->id)
+                    ->where('status', '!=', PaymentStatus::Cancelled->value);
+            })
+            ->pluck('participant_id')
+            ->unique()
+            ->toArray();
+
+        $duplicateCoachIds = array_intersect($registeredCoachIds, $this->selectedCoachIds);
+        if (count($duplicateCoachIds) > 0) {
+            $this->errorMessage = 'Sebagian pelatih sudah terdaftar di event ini.';
+            return;
+        }
+
+        if (count($this->selectedCoachIds) !== $this->coaches->count()) {
+            $this->errorMessage = 'Terdapat pelatih yang tidak valid.';
+            return;
+        }
+
+        if ($this->athleteSelections->count() === 0 && $this->coaches->count() === 0) {
+            $this->errorMessage = 'Pilih minimal satu atlet atau pelatih untuk membuat invoice.';
+            return;
+        }
+
+        DB::transaction(function () use ($contingent, $event) {
+            $payment = Payment::create([
+                'contingent_id' => $contingent->id,
+                'event_id' => $event->id,
+                'total_amount' => $this->totalAmount,
+                'status' => PaymentStatus::Pending->value,
+            ]);
+
+            $athleteRegistrations = [];
+            foreach ($this->athleteSelections as $selection) {
+                foreach ($selection['athletes'] as $athlete) {
+                    $athleteRegistrations[] = [
+                        'participant_id' => $athlete->id,
+                        'payment_id' => $payment->id,
+                        'sub_category_id' => $selection['subCategory']->id,
+                        'status_berkas' => RegistrationStatus::Unsubmitted->value,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+                }
+            }
+
+            $coachRegistrations = $this->coaches->map(fn ($coach) => [
+                'participant_id' => $coach->id,
+                'payment_id' => $payment->id,
+                'sub_category_id' => null,
+                'status_berkas' => RegistrationStatus::Verified->value,
+                'verified_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ])->all();
+
+            $payload = array_merge($athleteRegistrations, $coachRegistrations);
+            if (count($payload) > 0) {
+                Registration::insert($payload);
+            }
+
+            if ($this->draftId) {
+                RegistrationDraftItem::query()
+                    ->where('registration_draft_id', $this->draftId)
+                    ->delete();
+
+                RegistrationDraft::query()
+                    ->where('id', $this->draftId)
+                    ->update(['status' => 'converted']);
+            }
+        });
+
+        session()->flash('success', 'Invoice berhasil dibuat. Silakan lanjutkan pembayaran.');
+        $this->redirect(route('registration.index'), navigate: true);
+    }
+
+    public function render()
+    {
+        return view('livewire.event-registration-invoice');
+    }
+}

--- a/app/Livewire/EventRegistrationInvoice.php
+++ b/app/Livewire/EventRegistrationInvoice.php
@@ -146,7 +146,19 @@ class EventRegistrationInvoice extends Component
                 }
 
                 $list = collect($athleteIds)
-                    ->map(fn ($athleteId) => $athletes->get($athleteId))
+                    ->map(function ($athleteId) use ($athletes, $subCategoryId) {
+                        $athlete = $athletes->get($athleteId);
+                        if (!$athlete) return null;
+
+                        // Get team_group_id from draft items for this athlete in this sub-category
+                        $draftItem = RegistrationDraftItem::where('registration_draft_id', $this->draftId)
+                            ->where('sub_category_id', $subCategoryId)
+                            ->where('participant_id', $athleteId)
+                            ->first();
+
+                        $athlete->pivot_team_group_id = $draftItem ? $draftItem->team_group_id : null;
+                        return $athlete;
+                    })
                     ->filter()
                     ->values();
 
@@ -166,13 +178,23 @@ class EventRegistrationInvoice extends Component
             return 0;
         }
 
-        if ($this->athleteSelections->count() > 0) {
-            return $this->athleteSelections->sum(function (array $selection) {
-                return (float) $selection['subCategory']->price * $selection['athletes']->count();
-            });
-        }
+        return $this->athleteSelections->sum(function (array $selection) {
+            if ($selection['subCategory']->isTeam()) {
+                // Hitung jumlah tim unik dari atlet
+                $teamCount = collect($selection['athletes'])
+                    ->pluck('pivot_team_group_id')
+                    ->filter()
+                    ->unique()
+                    ->count();
 
-        return 0;
+                // Minimal 1 jika ada atlet tapi belum ada team_group_id (backward compat)
+                $teamCount = max($teamCount, 1);
+
+                return (float) $selection['subCategory']->price * $teamCount;
+            }
+            // Biaya Individu dikali jumlah atlet
+            return (float) $selection['subCategory']->price * $selection['athletes']->count();
+        });
     }
 
     #[Computed]
@@ -224,26 +246,44 @@ class EventRegistrationInvoice extends Component
         }
 
         if (count($this->selectedSubCategories) > 0) {
-            foreach ($this->selectedSubCategories as $subCategoryId => $athleteIds) {
-                $subCategory = SubCategory::with('eventCategory')->find($subCategoryId);
-                if (! $subCategory || $subCategory->eventCategory->event_id !== $event->id) {
-                    $this->errorMessage = 'Sub-kategori tidak valid untuk event ini.';
-                    return;
+            foreach ($this->athleteSelections as $selection) {
+                $subCategory = $selection['subCategory'];
+                $athletes = $selection['athletes'];
+
+                if ($subCategory->isTeam()) {
+                    // Validasi per tim
+                    $teams = $athletes->groupBy('pivot_team_group_id');
+                    
+                    if ($teams->isEmpty()) {
+                        $this->errorMessage = "Sub-kategori {$subCategory->name} harus memiliki minimal 1 tim.";
+                        return;
+                    }
+
+                    foreach ($teams as $teamId => $teamAthletes) {
+                        $count = $teamAthletes->count();
+                        if ($count < $subCategory->min_participants || $count > $subCategory->max_participants) {
+                            $this->errorMessage = "Tim pada {$subCategory->name} harus berisi {$subCategory->min_participants}-{$subCategory->max_participants} atlet.";
+                            return;
+                        }
+                    }
+                } else {
+                    // Validasi individu
+                    $athleteCount = $athletes->count();
+                    if ($athleteCount < $subCategory->min_participants || $athleteCount > $subCategory->max_participants) {
+                        $this->errorMessage = "Jumlah atlet pada {$subCategory->name} tidak sesuai ketentuan.";
+                        return;
+                    }
                 }
 
-                $athleteCount = count($athleteIds);
-                if ($athleteCount < $subCategory->min_participants || $athleteCount > $subCategory->max_participants) {
-                    $this->errorMessage = 'Jumlah atlet tidak sesuai dengan ketentuan sub-kategori.';
-                    return;
-                }
-
+                // Cek eligibility
+                $athleteIds = $athletes->pluck('id')->toArray();
                 $eligibleIds = Participant::eligibleFor($subCategory)
                     ->whereIn('id', $athleteIds)
                     ->pluck('id')
                     ->toArray();
 
-                if (count($eligibleIds) !== $athleteCount) {
-                    $this->errorMessage = 'Terdapat atlet yang tidak memenuhi syarat.';
+                if (count($eligibleIds) !== count($athleteIds)) {
+                    $this->errorMessage = "Terdapat atlet pada {$subCategory->name} yang tidak memenuhi syarat.";
                     return;
                 }
             }
@@ -290,6 +330,7 @@ class EventRegistrationInvoice extends Component
                         'participant_id' => $athlete->id,
                         'payment_id' => $payment->id,
                         'sub_category_id' => $selection['subCategory']->id,
+                        'team_group_id' => $athlete->pivot_team_group_id ?? null,
                         'status_berkas' => RegistrationStatus::Unsubmitted->value,
                         'created_at' => now(),
                         'updated_at' => now(),

--- a/app/Livewire/EventRegistrationWizard.php
+++ b/app/Livewire/EventRegistrationWizard.php
@@ -24,7 +24,6 @@ class EventRegistrationWizard extends Component
     public string $selectedEventName = '';
     public string $selectedCategoryName = '';
     public string $errorMessage = '';
-    public array $selectedCoachIds = [];
 
     public function mount(): void
     {
@@ -55,63 +54,9 @@ class EventRegistrationWizard extends Component
         $this->selectedEventId = $eventId;
         $this->ensureDraft($eventId, $contingent->id);
 
-        $this->selectedCoachIds = $this->getDraftCoachIds();
         $this->selectedEventName = $event->name;
         $this->currentStep = 2;
     }
-
-    public function updatedSelectedCoachIds(): void
-    {
-        $this->selectedCoachIds = array_values(array_unique(array_map('intval', $this->selectedCoachIds)));
-        $draft = $this->getActiveDraft();
-        if (! $draft) {
-            return;
-        }
-
-        $registrationService = app(RegistrationService::class);
-        $event = Event::find($this->selectedEventId);
-        if (! $event || ! $registrationService->isRegistrationOpen($event)) {
-            $this->errorMessage = 'Pendaftaran event sudah ditutup.';
-            return;
-        }
-
-        $registeredIds = $this->getRegisteredCoachIds();
-        if (count($registeredIds) > 0) {
-            $this->selectedCoachIds = array_values(array_diff($this->selectedCoachIds, $registeredIds));
-        }
-
-        $validCoachIds = $this->getCoaches()->pluck('id')->toArray();
-        $this->selectedCoachIds = array_values(array_intersect($this->selectedCoachIds, $validCoachIds));
-
-        $existingIds = RegistrationDraftItem::query()
-            ->where('registration_draft_id', $draft->id)
-            ->whereNull('sub_category_id')
-            ->pluck('participant_id')
-            ->toArray();
-
-        $toInsert = array_diff($this->selectedCoachIds, $existingIds);
-        $toDelete = array_diff($existingIds, $this->selectedCoachIds);
-
-        if (count($toInsert) > 0) {
-            $rows = collect($toInsert)->map(fn ($id) => [
-                'registration_draft_id' => $draft->id,
-                'participant_id' => $id,
-                'sub_category_id' => null,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ])->all();
-            RegistrationDraftItem::insert($rows);
-        }
-
-        if (count($toDelete) > 0) {
-            RegistrationDraftItem::query()
-                ->where('registration_draft_id', $draft->id)
-                ->whereNull('sub_category_id')
-                ->whereIn('participant_id', $toDelete)
-                ->delete();
-        }
-    }
-
 
     public function selectCategory(int $categoryId): void
     {
@@ -124,7 +69,6 @@ class EventRegistrationWizard extends Component
         $this->selectedCategoryId = $categoryId;
         $this->selectedCategoryName = $category->type->value . ' - ' . $category->class_name;
         $this->currentStep = 3;
-        $this->selectedCoachIds = $this->getDraftCoachIds();
     }
 
     public function selectSubCategory(int $subCategoryId): void
@@ -155,12 +99,10 @@ class EventRegistrationWizard extends Component
             $this->selectedCategoryId = null;
             $this->selectedCategoryName = '';
             $this->selectedSubCategoryId = null;
-            $this->selectedCoachIds = [];
         } elseif ($step === 2) {
             $this->selectedCategoryId = null;
             $this->selectedCategoryName = '';
             $this->selectedSubCategoryId = null;
-            $this->selectedCoachIds = $this->getDraftCoachIds();
         }
     }
 
@@ -180,11 +122,6 @@ class EventRegistrationWizard extends Component
             ],
             3 => [
                 'subCategories' => EventCategory::find($this->selectedCategoryId)?->subCategories ?? collect(),
-                'coaches' => $this->getCoaches(),
-                'draftSelections' => $this->getDraftSelections(),
-                'selectedCoachCount' => $this->getSelectedCoachCount(),
-                'registeredCoachIds' => $this->getRegisteredCoachIds(),
-                'draftCoachIds' => $this->getDraftCoachIds(),
             ],
             default => [],
         };
@@ -192,19 +129,6 @@ class EventRegistrationWizard extends Component
         return view('livewire.event-registration-wizard', $data);
     }
 
-
-    private function getSelectedCoachCount(): int
-    {
-        $draft = $this->getActiveDraft();
-        if (! $draft) {
-            return 0;
-        }
-
-        return RegistrationDraftItem::query()
-            ->where('registration_draft_id', $draft->id)
-            ->whereNull('sub_category_id')
-            ->count();
-    }
 
     private function getDraftSelections(): Collection
     {
@@ -265,58 +189,5 @@ class EventRegistrationWizard extends Component
             ->where('event_id', $this->selectedEventId)
             ->where('status', 'draft')
             ->first();
-    }
-
-    private function getCoaches(): Collection
-    {
-        $contingent = auth()->user()->contingent;
-        if (! $contingent) {
-            return collect();
-        }
-
-        return Participant::coaches()
-            ->where('contingent_id', $contingent->id)
-            ->orderBy('name')
-            ->get();
-    }
-
-    private function getDraftCoachIds(): array
-    {
-        $draft = $this->getActiveDraft();
-        if (! $draft) {
-            return [];
-        }
-
-        return RegistrationDraftItem::query()
-            ->where('registration_draft_id', $draft->id)
-            ->whereNull('sub_category_id')
-            ->pluck('participant_id')
-            ->unique()
-            ->toArray();
-    }
-
-    private function getRegisteredCoachIds(): array
-    {
-        if (! $this->selectedEventId) {
-            return [];
-        }
-
-        $contingent = auth()->user()->contingent;
-        if (! $contingent) {
-            return [];
-        }
-
-        return Registration::query()
-            ->whereNull('sub_category_id')
-            ->whereHas('payment', function ($query) {
-                $query->where('event_id', $this->selectedEventId)
-                    ->where('status', '!=', \App\Enums\PaymentStatus::Cancelled->value);
-            })
-            ->whereHas('participant', function ($query) use ($contingent) {
-                $query->where('contingent_id', $contingent->id);
-            })
-            ->pluck('participant_id')
-            ->unique()
-            ->toArray();
     }
 }

--- a/app/Livewire/EventRegistrationWizard.php
+++ b/app/Livewire/EventRegistrationWizard.php
@@ -122,6 +122,7 @@ class EventRegistrationWizard extends Component
             ],
             3 => [
                 'subCategories' => EventCategory::find($this->selectedCategoryId)?->subCategories ?? collect(),
+                'draftSelections' => $this->getDraftSelections(),
             ],
             default => [],
         };
@@ -137,35 +138,28 @@ class EventRegistrationWizard extends Component
             return collect();
         }
 
-        $athleteCounts = RegistrationDraftItem::query()
-            ->selectRaw('sub_category_id, COUNT(*) as total')
+        return RegistrationDraftItem::query()
             ->where('registration_draft_id', $draft->id)
             ->whereNotNull('sub_category_id')
-            ->groupBy('sub_category_id')
-            ->get();
-
-        if ($athleteCounts->count() === 0) {
-            return collect();
-        }
-
-        $subCategories = SubCategory::whereIn('id', $athleteCounts->pluck('sub_category_id'))
-            ->with('eventCategory')
+            ->with(['participant', 'subCategory.eventCategory'])
             ->get()
-            ->keyBy('id');
+            ->groupBy('sub_category_id')
+            ->map(function ($items, $subCategoryId) {
+                $first = $items->first();
+                $subCategory = $first->subCategory;
+                
+                $data = [
+                    'subCategory' => $subCategory,
+                    'athlete_count' => $items->count(),
+                    'athlete_names' => $items->pluck('participant.name')->toArray(),
+                ];
 
-        return $athleteCounts
-            ->map(function ($item) use ($subCategories) {
-                $subCategory = $subCategories->get($item->sub_category_id);
-                if (! $subCategory) {
-                    return null;
+                if ($subCategory->isTeam()) {
+                    $data['team_count'] = $items->pluck('team_group_id')->filter()->unique()->count();
                 }
 
-                return [
-                    'subCategory' => $subCategory,
-                    'athlete_count' => (int) $item->total,
-                ];
+                return $data;
             })
-            ->filter()
             ->values();
     }
 

--- a/app/Livewire/EventRegistrationWizard.php
+++ b/app/Livewire/EventRegistrationWizard.php
@@ -2,9 +2,16 @@
 
 namespace App\Livewire;
 
+use App\Enums\PaymentStatus;
 use App\Models\Event;
 use App\Models\EventCategory;
+use App\Models\Participant;
+use App\Models\Registration;
+use App\Models\RegistrationDraft;
+use App\Models\RegistrationDraftItem;
+use App\Models\SubCategory;
 use App\Services\RegistrationService;
+use Illuminate\Support\Collection;
 use Livewire\Component;
 
 class EventRegistrationWizard extends Component
@@ -17,10 +24,10 @@ class EventRegistrationWizard extends Component
     public string $selectedEventName = '';
     public string $selectedCategoryName = '';
     public string $errorMessage = '';
+    public array $selectedCoachIds = [];
 
     public function mount(): void
     {
-        // Inisialisasi awal. Data daftar event akan diload di render()
     }
 
     public function selectEvent(int $eventId, RegistrationService $registrationService): void
@@ -46,9 +53,65 @@ class EventRegistrationWizard extends Component
         }
 
         $this->selectedEventId = $eventId;
+        $this->ensureDraft($eventId, $contingent->id);
+
+        $this->selectedCoachIds = $this->getDraftCoachIds();
         $this->selectedEventName = $event->name;
         $this->currentStep = 2;
     }
+
+    public function updatedSelectedCoachIds(): void
+    {
+        $this->selectedCoachIds = array_values(array_unique(array_map('intval', $this->selectedCoachIds)));
+        $draft = $this->getActiveDraft();
+        if (! $draft) {
+            return;
+        }
+
+        $registrationService = app(RegistrationService::class);
+        $event = Event::find($this->selectedEventId);
+        if (! $event || ! $registrationService->isRegistrationOpen($event)) {
+            $this->errorMessage = 'Pendaftaran event sudah ditutup.';
+            return;
+        }
+
+        $registeredIds = $this->getRegisteredCoachIds();
+        if (count($registeredIds) > 0) {
+            $this->selectedCoachIds = array_values(array_diff($this->selectedCoachIds, $registeredIds));
+        }
+
+        $validCoachIds = $this->getCoaches()->pluck('id')->toArray();
+        $this->selectedCoachIds = array_values(array_intersect($this->selectedCoachIds, $validCoachIds));
+
+        $existingIds = RegistrationDraftItem::query()
+            ->where('registration_draft_id', $draft->id)
+            ->whereNull('sub_category_id')
+            ->pluck('participant_id')
+            ->toArray();
+
+        $toInsert = array_diff($this->selectedCoachIds, $existingIds);
+        $toDelete = array_diff($existingIds, $this->selectedCoachIds);
+
+        if (count($toInsert) > 0) {
+            $rows = collect($toInsert)->map(fn ($id) => [
+                'registration_draft_id' => $draft->id,
+                'participant_id' => $id,
+                'sub_category_id' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ])->all();
+            RegistrationDraftItem::insert($rows);
+        }
+
+        if (count($toDelete) > 0) {
+            RegistrationDraftItem::query()
+                ->where('registration_draft_id', $draft->id)
+                ->whereNull('sub_category_id')
+                ->whereIn('participant_id', $toDelete)
+                ->delete();
+        }
+    }
+
 
     public function selectCategory(int $categoryId): void
     {
@@ -61,6 +124,7 @@ class EventRegistrationWizard extends Component
         $this->selectedCategoryId = $categoryId;
         $this->selectedCategoryName = $category->type->value . ' - ' . $category->class_name;
         $this->currentStep = 3;
+        $this->selectedCoachIds = $this->getDraftCoachIds();
     }
 
     public function selectSubCategory(int $subCategoryId): void
@@ -91,10 +155,12 @@ class EventRegistrationWizard extends Component
             $this->selectedCategoryId = null;
             $this->selectedCategoryName = '';
             $this->selectedSubCategoryId = null;
+            $this->selectedCoachIds = [];
         } elseif ($step === 2) {
             $this->selectedCategoryId = null;
             $this->selectedCategoryName = '';
             $this->selectedSubCategoryId = null;
+            $this->selectedCoachIds = $this->getDraftCoachIds();
         }
     }
 
@@ -104,17 +170,153 @@ class EventRegistrationWizard extends Component
 
         $data = match ($this->currentStep) {
             1 => [
-                'events' => $registrationService->getOpenEvents()
+                'events' => $registrationService->getOpenEvents(),
+                'statusLabels' => $registrationService->getOpenEvents()->mapWithKeys(
+                    fn ($event) => [$event->id => $registrationService->getRegistrationStatusLabel($event)]
+                ),
             ],
             2 => [
                 'categoriesGrouped' => $registrationService->getCategoriesForEvent($this->selectedEventId)
             ],
             3 => [
-                'subCategories' => EventCategory::find($this->selectedCategoryId)?->subCategories ?? collect()
+                'subCategories' => EventCategory::find($this->selectedCategoryId)?->subCategories ?? collect(),
+                'coaches' => $this->getCoaches(),
+                'draftSelections' => $this->getDraftSelections(),
+                'selectedCoachCount' => $this->getSelectedCoachCount(),
+                'registeredCoachIds' => $this->getRegisteredCoachIds(),
+                'draftCoachIds' => $this->getDraftCoachIds(),
             ],
             default => [],
         };
 
         return view('livewire.event-registration-wizard', $data);
+    }
+
+
+    private function getSelectedCoachCount(): int
+    {
+        $draft = $this->getActiveDraft();
+        if (! $draft) {
+            return 0;
+        }
+
+        return RegistrationDraftItem::query()
+            ->where('registration_draft_id', $draft->id)
+            ->whereNull('sub_category_id')
+            ->count();
+    }
+
+    private function getDraftSelections(): Collection
+    {
+        $draft = $this->getActiveDraft();
+        if (! $draft) {
+            return collect();
+        }
+
+        $athleteCounts = RegistrationDraftItem::query()
+            ->selectRaw('sub_category_id, COUNT(*) as total')
+            ->where('registration_draft_id', $draft->id)
+            ->whereNotNull('sub_category_id')
+            ->groupBy('sub_category_id')
+            ->get();
+
+        if ($athleteCounts->count() === 0) {
+            return collect();
+        }
+
+        $subCategories = SubCategory::whereIn('id', $athleteCounts->pluck('sub_category_id'))
+            ->with('eventCategory')
+            ->get()
+            ->keyBy('id');
+
+        return $athleteCounts
+            ->map(function ($item) use ($subCategories) {
+                $subCategory = $subCategories->get($item->sub_category_id);
+                if (! $subCategory) {
+                    return null;
+                }
+
+                return [
+                    'subCategory' => $subCategory,
+                    'athlete_count' => (int) $item->total,
+                ];
+            })
+            ->filter()
+            ->values();
+    }
+
+    private function ensureDraft(int $eventId, int $contingentId): RegistrationDraft
+    {
+        return RegistrationDraft::firstOrCreate([
+            'contingent_id' => $contingentId,
+            'event_id' => $eventId,
+            'status' => 'draft',
+        ]);
+    }
+
+    private function getActiveDraft(): ?RegistrationDraft
+    {
+        $contingent = auth()->user()->contingent;
+        if (! $contingent || ! $this->selectedEventId) {
+            return null;
+        }
+
+        return RegistrationDraft::where('contingent_id', $contingent->id)
+            ->where('event_id', $this->selectedEventId)
+            ->where('status', 'draft')
+            ->first();
+    }
+
+    private function getCoaches(): Collection
+    {
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            return collect();
+        }
+
+        return Participant::coaches()
+            ->where('contingent_id', $contingent->id)
+            ->orderBy('name')
+            ->get();
+    }
+
+    private function getDraftCoachIds(): array
+    {
+        $draft = $this->getActiveDraft();
+        if (! $draft) {
+            return [];
+        }
+
+        return RegistrationDraftItem::query()
+            ->where('registration_draft_id', $draft->id)
+            ->whereNull('sub_category_id')
+            ->pluck('participant_id')
+            ->unique()
+            ->toArray();
+    }
+
+    private function getRegisteredCoachIds(): array
+    {
+        if (! $this->selectedEventId) {
+            return [];
+        }
+
+        $contingent = auth()->user()->contingent;
+        if (! $contingent) {
+            return [];
+        }
+
+        return Registration::query()
+            ->whereNull('sub_category_id')
+            ->whereHas('payment', function ($query) {
+                $query->where('event_id', $this->selectedEventId)
+                    ->where('status', '!=', \App\Enums\PaymentStatus::Cancelled->value);
+            })
+            ->whereHas('participant', function ($query) use ($contingent) {
+                $query->where('contingent_id', $contingent->id);
+            })
+            ->pluck('participant_id')
+            ->unique()
+            ->toArray();
     }
 }

--- a/app/Models/Participant.php
+++ b/app/Models/Participant.php
@@ -56,6 +56,25 @@ class Participant extends Model
         return $this->hasMany(Registration::class);
     }
 
+    public function registrationsForEvent(int $eventId): HasMany
+    {
+        return $this->registrations()->whereHas('payment', function($q) use ($eventId) {
+            $q->where('event_id', $eventId)->where('status', '!=', \App\Enums\PaymentStatus::Cancelled);
+        });
+    }
+
+    public function draftItems(): HasMany
+    {
+        return $this->hasMany(RegistrationDraftItem::class);
+    }
+
+    public function draftItemsForEvent(int $eventId): HasMany
+    {
+        return $this->draftItems()->whereHas('draft', function($q) use ($eventId) {
+            $q->where('event_id', $eventId)->where('status', 'draft');
+        });
+    }
+
     public function scopeAthletes($query)
     {
         return $query->where('type', ParticipantType::Athlete);

--- a/app/Models/Registration.php
+++ b/app/Models/Registration.php
@@ -21,6 +21,7 @@ class Registration extends Model
         'rejection_reason',
         'verified_at',
         'verified_by',
+        'team_group_id',
     ];
 
     protected function casts(): array
@@ -44,6 +45,11 @@ class Registration extends Model
     public function subCategory(): BelongsTo
     {
         return $this->belongsTo(SubCategory::class);
+    }
+
+    public function teamGroup(): BelongsTo
+    {
+        return $this->belongsTo(TeamGroup::class);
     }
 
     public function verifiedBy(): BelongsTo

--- a/app/Models/RegistrationDraft.php
+++ b/app/Models/RegistrationDraft.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class RegistrationDraft extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'contingent_id',
+        'event_id',
+        'status',
+    ];
+
+    public function contingent(): BelongsTo
+    {
+        return $this->belongsTo(Contingent::class);
+    }
+
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(RegistrationDraftItem::class);
+    }
+}

--- a/app/Models/RegistrationDraftItem.php
+++ b/app/Models/RegistrationDraftItem.php
@@ -14,6 +14,7 @@ class RegistrationDraftItem extends Model
         'registration_draft_id',
         'participant_id',
         'sub_category_id',
+        'team_group_id',
     ];
 
     public function draft(): BelongsTo
@@ -29,5 +30,10 @@ class RegistrationDraftItem extends Model
     public function subCategory(): BelongsTo
     {
         return $this->belongsTo(SubCategory::class);
+    }
+
+    public function teamGroup(): BelongsTo
+    {
+        return $this->belongsTo(TeamGroup::class);
     }
 }

--- a/app/Models/RegistrationDraftItem.php
+++ b/app/Models/RegistrationDraftItem.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RegistrationDraftItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'registration_draft_id',
+        'participant_id',
+        'sub_category_id',
+    ];
+
+    public function draft(): BelongsTo
+    {
+        return $this->belongsTo(RegistrationDraft::class, 'registration_draft_id');
+    }
+
+    public function participant(): BelongsTo
+    {
+        return $this->belongsTo(Participant::class);
+    }
+
+    public function subCategory(): BelongsTo
+    {
+        return $this->belongsTo(SubCategory::class);
+    }
+}

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -15,10 +15,12 @@ class SubCategory extends Model
     protected $fillable = [
         'event_category_id',
         'name',
+        'category_type',
         'gender',
         'price',
         'min_participants',
         'max_participants',
+        'max_teams',
     ];
 
     protected function casts(): array
@@ -28,6 +30,7 @@ class SubCategory extends Model
             'price' => 'decimal:2',
             'min_participants' => 'integer',
             'max_participants' => 'integer',
+            'max_teams' => 'integer',
         ];
     }
 
@@ -41,9 +44,14 @@ class SubCategory extends Model
         return $this->hasMany(Registration::class);
     }
 
+    public function teamGroups(): HasMany
+    {
+        return $this->hasMany(TeamGroup::class);
+    }
+
     public function isTeam(): bool
     {
-        return $this->max_participants > 1;
+        return $this->category_type === 'beregu';
     }
 
     public function hasActiveRegistrations(): bool

--- a/app/Models/TeamGroup.php
+++ b/app/Models/TeamGroup.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class TeamGroup extends Model
+{
+    protected $fillable = [
+        'contingent_id',
+        'sub_category_id',
+        'team_name',
+        'team_number',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'team_number' => 'integer',
+        ];
+    }
+
+    public function contingent(): BelongsTo
+    {
+        return $this->belongsTo(Contingent::class);
+    }
+
+    public function subCategory(): BelongsTo
+    {
+        return $this->belongsTo(SubCategory::class);
+    }
+
+    public function draftItems(): HasMany
+    {
+        return $this->hasMany(RegistrationDraftItem::class);
+    }
+
+    public function registrations(): HasMany
+    {
+        return $this->hasMany(Registration::class);
+    }
+
+    /**
+     * Ambil daftar participant yang tergabung di tim ini (dari draft).
+     */
+    public function draftParticipants()
+    {
+        return $this->draftItems()->with('participant');
+    }
+}

--- a/database/factories/ContingentFactory.php
+++ b/database/factories/ContingentFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ContingentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => fake()->company(),
+            'official_name' => fake()->name(),
+            'phone' => fake()->phoneNumber(),
+            'address' => fake()->address(),
+        ];
+    }
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\EventStatus;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class EventFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->sentence(3),
+            'poster' => null,
+            'event_date' => now()->addMonth(),
+            'registration_deadline' => now()->addWeeks(2),
+            'coach_fee' => 100000,
+            'event_fee' => 250000,
+            'status' => EventStatus::RegistrationOpen,
+        ];
+    }
+}

--- a/database/factories/ParticipantFactory.php
+++ b/database/factories/ParticipantFactory.php
@@ -22,8 +22,8 @@ class ParticipantFactory extends Factory
             'gender' => fake()->randomElement([ParticipantGender::Male, ParticipantGender::Female]),
             'provinsi' => fake()->state(),
             'institusi' => fake()->company(),
-            'photo' => null,
-            'document' => null,
+            'photo' => 'assets/media/avatars/blank.png',
+            'document' => 'assets/media/documents/dummy.pdf',
             'is_verified' => false,
         ];
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,6 +26,7 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
+            'username' => fake()->unique()->userName(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2026_05_05_083651_add_category_type_to_sub_categories_table.php
+++ b/database/migrations/2026_05_05_083651_add_category_type_to_sub_categories_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sub_categories', function (Blueprint $table) {
+            $table->enum('category_type', ['individu', 'beregu'])->default('individu')->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sub_categories', function (Blueprint $table) {
+            $table->dropColumn('category_type');
+        });
+    }
+};

--- a/database/migrations/2026_05_05_091021_add_max_teams_to_sub_categories_table.php
+++ b/database/migrations/2026_05_05_091021_add_max_teams_to_sub_categories_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sub_categories', function (Blueprint $table) {
+            $table->unsignedSmallInteger('max_teams')->default(1)->after('max_participants');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sub_categories', function (Blueprint $table) {
+            $table->dropColumn('max_teams');
+        });
+    }
+};

--- a/database/migrations/2026_05_05_091025_create_team_groups_table.php
+++ b/database/migrations/2026_05_05_091025_create_team_groups_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('team_groups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('contingent_id')->constrained()->restrictOnDelete();
+            $table->foreignId('sub_category_id')->constrained()->restrictOnDelete();
+            $table->string('team_name');           // "Tim A", "Tim B"
+            $table->unsignedSmallInteger('team_number')->default(1); // urutan: 1, 2, 3
+            $table->timestamps();
+
+            // Unique: 1 kontingen tidak boleh punya 2 tim dengan nomor sama di sub-kategori sama
+            $table->unique(['contingent_id', 'sub_category_id', 'team_number']);
+            $table->index('sub_category_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('team_groups');
+    }
+};

--- a/database/migrations/2026_05_05_091029_add_team_group_id_to_registration_tables.php
+++ b/database/migrations/2026_05_05_091029_add_team_group_id_to_registration_tables.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('registration_draft_items', function (Blueprint $table) {
+            $table->foreignId('team_group_id')->nullable()->after('sub_category_id')
+                  ->constrained('team_groups')->nullOnDelete();
+        });
+
+        Schema::table('registrations', function (Blueprint $table) {
+            $table->foreignId('team_group_id')->nullable()->after('sub_category_id')
+                  ->constrained('team_groups')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('registration_draft_items', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('team_group_id');
+        });
+        Schema::table('registrations', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('team_group_id');
+        });
+    }
+};

--- a/database/migrations/2026_05_05_120000_create_registration_drafts_table.php
+++ b/database/migrations/2026_05_05_120000_create_registration_drafts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('registration_drafts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('contingent_id')->constrained()->restrictOnDelete();
+            $table->foreignId('event_id')->constrained()->restrictOnDelete();
+            $table->enum('status', ['draft', 'converted', 'expired'])->default('draft')->notNull();
+            $table->timestamps();
+
+            $table->index(['contingent_id', 'event_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('registration_drafts');
+    }
+};

--- a/database/migrations/2026_05_05_120100_create_registration_draft_items_table.php
+++ b/database/migrations/2026_05_05_120100_create_registration_draft_items_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('registration_draft_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('registration_draft_id')->constrained('registration_drafts')->cascadeOnDelete();
+            $table->foreignId('participant_id')->constrained()->restrictOnDelete();
+            $table->foreignId('sub_category_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+
+            $table->index('registration_draft_id');
+            $table->index(['participant_id', 'sub_category_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('registration_draft_items');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,7 +18,8 @@ class DatabaseSeeder extends Seeder
 
         $this->call([
             RolesAndPermissionsSeeder::class,
-            // Seeder lain (misal produk, kategori) bisa ditaruh di bawah sini
+            ParticipantSeeder::class,
+            EventSeeder::class,
         ]);
     }
 }

--- a/database/seeders/EventSeeder.php
+++ b/database/seeders/EventSeeder.php
@@ -33,12 +33,12 @@ class EventSeeder extends Seeder
         $types = ['Open', 'Festival'];
 
         $subCategories = [
-            ['name' => 'KATA Individu Putra', 'gender' => 'M', 'price' => 250000, 'min' => 1, 'max' => 1],
-            ['name' => 'KATA Individu Putri', 'gender' => 'F', 'price' => 250000, 'min' => 1, 'max' => 1],
-            ['name' => 'KATA Beregu Putra', 'gender' => 'M', 'price' => 500000, 'min' => 3, 'max' => 3],
-            ['name' => 'KATA Beregu Putri', 'gender' => 'F', 'price' => 500000, 'min' => 3, 'max' => 3],
-            ['name' => 'KUMITE Individu Putra', 'gender' => 'M', 'price' => 250000, 'min' => 1, 'max' => 1],
-            ['name' => 'KUMITE Individu Putri', 'gender' => 'F', 'price' => 250000, 'min' => 1, 'max' => 1],
+            ['name' => 'KATA Individu Putra', 'category_type' => 'individu', 'gender' => 'M', 'price' => 250000, 'min' => 1, 'max' => 1, 'max_teams' => 1],
+            ['name' => 'KATA Individu Putri', 'category_type' => 'individu', 'gender' => 'F', 'price' => 250000, 'min' => 1, 'max' => 1, 'max_teams' => 1],
+            ['name' => 'KATA Beregu Putra', 'category_type' => 'beregu', 'gender' => 'M', 'price' => 500000, 'min' => 3, 'max' => 3, 'max_teams' => 2],
+            ['name' => 'KATA Beregu Putri', 'category_type' => 'beregu', 'gender' => 'F', 'price' => 500000, 'min' => 3, 'max' => 3, 'max_teams' => 2],
+            ['name' => 'KUMITE Individu Putra', 'category_type' => 'individu', 'gender' => 'M', 'price' => 250000, 'min' => 1, 'max' => 1, 'max_teams' => 1],
+            ['name' => 'KUMITE Individu Putri', 'category_type' => 'individu', 'gender' => 'F', 'price' => 250000, 'min' => 1, 'max' => 1, 'max_teams' => 1],
         ];
 
         foreach ($types as $type) {
@@ -62,10 +62,12 @@ class EventSeeder extends Seeder
                             'name' => $subCategory['name'],
                         ],
                         [
+                            'category_type' => $subCategory['category_type'],
                             'gender' => $subCategory['gender'],
                             'price' => $subCategory['price'],
                             'min_participants' => $subCategory['min'],
                             'max_participants' => $subCategory['max'],
+                            'max_teams' => $subCategory['max_teams'] ?? 1,
                         ]
                     );
                 }

--- a/database/seeders/EventSeeder.php
+++ b/database/seeders/EventSeeder.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Event;
+use App\Models\EventCategory;
+use App\Models\SubCategory;
+use App\Enums\SubCategoryGender;
+use Illuminate\Database\Seeder;
+
+class EventSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $event = Event::updateOrCreate(
+            ['name' => 'Piala Karate Indonesia 2026'],
+            [
+                'event_date' => '2026-08-01',
+                'registration_deadline' => '2026-07-15 23:59:59',
+                'coach_fee' => 500000,
+                'event_fee' => 250000,
+                'status' => 'registration_open',
+            ]
+        );
+
+        $classes = [
+            // Usia di tahun 2026
+            'JUNIOR' => ['min' => '2009-01-01', 'max' => '2010-12-31'],
+            'U21' => ['min' => '2006-01-01', 'max' => '2008-12-31'],
+            'DEWASA' => ['min' => '1996-01-01', 'max' => '2005-12-31'],
+        ];
+
+        $types = ['Open', 'Festival'];
+
+        $subCategories = [
+            ['name' => 'KATA Individu Putra', 'gender' => 'M', 'price' => 250000, 'min' => 1, 'max' => 1],
+            ['name' => 'KATA Individu Putri', 'gender' => 'F', 'price' => 250000, 'min' => 1, 'max' => 1],
+            ['name' => 'KATA Beregu Putra', 'gender' => 'M', 'price' => 500000, 'min' => 3, 'max' => 3],
+            ['name' => 'KATA Beregu Putri', 'gender' => 'F', 'price' => 500000, 'min' => 3, 'max' => 3],
+            ['name' => 'KUMITE Individu Putra', 'gender' => 'M', 'price' => 250000, 'min' => 1, 'max' => 1],
+            ['name' => 'KUMITE Individu Putri', 'gender' => 'F', 'price' => 250000, 'min' => 1, 'max' => 1],
+        ];
+
+        foreach ($types as $type) {
+            foreach ($classes as $className => $range) {
+                $category = EventCategory::updateOrCreate(
+                    [
+                        'event_id' => $event->id,
+                        'type' => $type,
+                        'class_name' => $className,
+                    ],
+                    [
+                        'min_birth_date' => $range['min'],
+                        'max_birth_date' => $range['max'],
+                    ]
+                );
+
+                foreach ($subCategories as $subCategory) {
+                    SubCategory::updateOrCreate(
+                        [
+                            'event_category_id' => $category->id,
+                            'name' => $subCategory['name'],
+                        ],
+                        [
+                            'gender' => $subCategory['gender'],
+                            'price' => $subCategory['price'],
+                            'min_participants' => $subCategory['min'],
+                            'max_participants' => $subCategory['max'],
+                        ]
+                    );
+                }
+            }
+        }
+
+        $this->command->info('EventSeeder: Event, Categories (Open/Festival), and SubCategories created.');
+    }
+}

--- a/database/seeders/ParticipantSeeder.php
+++ b/database/seeders/ParticipantSeeder.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Contingent;
+use App\Models\Participant;
+use App\Enums\ParticipantType;
+use App\Enums\ParticipantGender;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class ParticipantSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $contingent = Contingent::first();
+
+        if (!$contingent) {
+            $this->command->warn('No contingent found. Please run RolesAndPermissionsSeeder first.');
+            return;
+        }
+
+        $athletes = [
+            // JUNIOR (2009-2010)
+            ['name' => 'Ari Pratama', 'gender' => 'M', 'birth_date' => '2009-03-12', 'nik' => '3201010102010001', 'photo' => 'assets/media/avatars/150-1.jpg'],
+            ['name' => 'Bagas Saputra', 'gender' => 'M', 'birth_date' => '2010-07-21', 'nik' => '3201010102010002', 'photo' => 'assets/media/avatars/150-2.jpg'],
+            ['name' => 'Cahya Nugroho', 'gender' => 'M', 'birth_date' => '2009-11-08', 'nik' => '3201010102010003', 'photo' => 'assets/media/avatars/150-3.jpg'],
+            ['name' => 'Dinda Permata', 'gender' => 'F', 'birth_date' => '2009-02-14', 'nik' => '3201010102010004', 'photo' => 'assets/media/avatars/150-4.jpg'],
+            ['name' => 'Eka Lestari', 'gender' => 'F', 'birth_date' => '2010-09-05', 'nik' => '3201010102010005', 'photo' => 'assets/media/avatars/150-5.jpg'],
+            ['name' => 'Fina Putri', 'gender' => 'F', 'birth_date' => '2009-06-30', 'nik' => '3201010102010006', 'photo' => 'assets/media/avatars/150-6.jpg'],
+
+            // U21 (2006-2008)
+            ['name' => 'Galih Santosa', 'gender' => 'M', 'birth_date' => '2006-01-19', 'nik' => '3201010102010007', 'photo' => 'assets/media/avatars/150-7.jpg'],
+            ['name' => 'Hadi Setiawan', 'gender' => 'M', 'birth_date' => '2007-05-24', 'nik' => '3201010102010008', 'photo' => 'assets/media/avatars/150-8.jpg'],
+            ['name' => 'Irfan Maulana', 'gender' => 'M', 'birth_date' => '2008-10-03', 'nik' => '3201010102010009', 'photo' => 'assets/media/avatars/150-9.jpg'],
+            ['name' => 'Jihan Aulia', 'gender' => 'F', 'birth_date' => '2006-03-10', 'nik' => '3201010102010010', 'photo' => 'assets/media/avatars/150-10.jpg'],
+            ['name' => 'Kartika Sari', 'gender' => 'F', 'birth_date' => '2007-12-28', 'nik' => '3201010102010011', 'photo' => 'assets/media/avatars/150-11.jpg'],
+            ['name' => 'Laras Wulandari', 'gender' => 'F', 'birth_date' => '2008-08-16', 'nik' => '3201010102010012', 'photo' => 'assets/media/avatars/150-12.jpg'],
+
+            // DEWASA (1996-2005)
+            ['name' => 'Miko Ardiansyah', 'gender' => 'M', 'birth_date' => '1999-04-17', 'nik' => '3201010102010013', 'photo' => 'assets/media/avatars/150-13.jpg'],
+            ['name' => 'Nanda Prakoso', 'gender' => 'M', 'birth_date' => '2001-09-09', 'nik' => '3201010102010014', 'photo' => 'assets/media/avatars/150-14.jpg'],
+            ['name' => 'Oki Ramadhan', 'gender' => 'M', 'birth_date' => '2004-12-02', 'nik' => '3201010102010015', 'photo' => 'assets/media/avatars/150-15.jpg'],
+            ['name' => 'Putri Larasati', 'gender' => 'F', 'birth_date' => '1998-06-06', 'nik' => '3201010102010016', 'photo' => 'assets/media/avatars/150-16.jpg'],
+            ['name' => 'Qori Azzahra', 'gender' => 'F', 'birth_date' => '2002-02-27', 'nik' => '3201010102010017', 'photo' => 'assets/media/avatars/150-17.jpg'],
+            ['name' => 'Rina Maharani', 'gender' => 'F', 'birth_date' => '2005-11-19', 'nik' => '3201010102010018', 'photo' => 'assets/media/avatars/150-18.jpg'],
+        ];
+
+        foreach ($athletes as $athlete) {
+            Participant::updateOrCreate(
+                ['nik' => $athlete['nik']],
+                [
+                    'contingent_id' => $contingent->id,
+                    'type' => 'athlete',
+                    'name' => $athlete['name'],
+                    'birth_date' => $athlete['birth_date'],
+                    'gender' => $athlete['gender'],
+                    'provinsi' => 'Jawa Barat',
+                    'institusi' => 'Dojo Karate Hebat',
+                    'photo' => $athlete['photo'],
+                    'is_verified' => true,
+                    'verified_at' => now(),
+                ]
+            );
+        }
+
+        $coaches = [
+            ['nik' => '3201010102090001', 'name' => 'Sensei Arman', 'gender' => 'M', 'photo' => 'assets/media/avatars/150-19.jpg'],
+            ['nik' => '3201010102090002', 'name' => 'Sensei Rahayu', 'gender' => 'F', 'photo' => 'assets/media/avatars/150-20.jpg'],
+            ['nik' => '3201010102090003', 'name' => 'Sensei Fauzan', 'gender' => 'M', 'photo' => 'assets/media/avatars/150-21.jpg'],
+        ];
+
+        foreach ($coaches as $coach) {
+            Participant::updateOrCreate(
+                ['nik' => $coach['nik']],
+                [
+                    'contingent_id' => $contingent->id,
+                    'type' => 'coach',
+                    'name' => $coach['name'],
+                    'gender' => $coach['gender'],
+                    'photo' => $coach['photo'],
+                    'is_verified' => true,
+                ]
+            );
+        }
+
+        $officials = [
+            ['nik' => '3201010102091001', 'name' => 'Official Yudha', 'gender' => 'M', 'photo' => 'assets/media/avatars/150-22.jpg'],
+            ['nik' => '3201010102091002', 'name' => 'Official Melati', 'gender' => 'F', 'photo' => 'assets/media/avatars/150-23.jpg'],
+            ['nik' => '3201010102091003', 'name' => 'Official Raka', 'gender' => 'M', 'photo' => 'assets/media/avatars/150-24.jpg'],
+            ['nik' => '3201010102091004', 'name' => 'Official Sinta', 'gender' => 'F', 'photo' => 'assets/media/avatars/150-25.jpg'],
+        ];
+
+        foreach ($officials as $official) {
+            Participant::updateOrCreate(
+                ['nik' => $official['nik']],
+                [
+                    'contingent_id' => $contingent->id,
+                    'type' => 'official',
+                    'name' => $official['name'],
+                    'gender' => $official['gender'],
+                    'photo' => $official['photo'],
+                    'is_verified' => true,
+                ]
+            );
+        }
+
+        $this->command->info('ParticipantSeeder: 18 athletes, 3 coaches, and 4 officials created.');
+    }
+}

--- a/resources/css/registration.css
+++ b/resources/css/registration.css
@@ -1,0 +1,108 @@
+/* Registration module styles */
+
+/* Custom Timeline Stepper */
+.custom-stepper {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    position: relative;
+}
+
+.custom-stepper::before {
+    content: '';
+    position: absolute;
+    left: 19px;
+    top: 40px;
+    bottom: 40px;
+    width: 2px;
+    background: #e4e6ef;
+}
+
+.custom-stepper-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    position: relative;
+}
+
+.custom-stepper-circle {
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #f5f8fa;
+    border: 2px solid #e4e6ef;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 1rem;
+    color: #7e8299;
+    transition: all 0.3s ease;
+    z-index: 1;
+}
+
+.custom-stepper-item.completed .custom-stepper-circle {
+    background: #009ef7;
+    border-color: #009ef7;
+    color: #ffffff;
+}
+
+.custom-stepper-item.active .custom-stepper-circle {
+    background: #009ef7;
+    border-color: #009ef7;
+    color: #ffffff;
+    box-shadow: 0 0 0 4px rgba(0, 158, 247, 0.2);
+}
+
+.custom-stepper-content {
+    padding-top: 6px;
+}
+
+.custom-stepper-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #181c32;
+    margin-bottom: 0.25rem;
+}
+
+.custom-stepper-item.active .custom-stepper-title {
+    color: #009ef7;
+}
+
+.custom-stepper-desc {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #7e8299;
+    margin-bottom: 0;
+}
+
+.custom-stepper-item.active .custom-stepper-desc {
+    color: #5e6278;
+}
+
+/* Athlete Photos */
+.athlete-photo {
+    width: 50px;
+    height: 50px;
+    object-fit: cover;
+}
+
+.athlete-photo-ineligible {
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
+    filter: grayscale(100%);
+    opacity: 0.6;
+}
+
+.coach-photo {
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
+}
+
+.sticky-summary {
+    position: sticky;
+    top: calc(var(--kt-header-height, 65px) + var(--kt-toolbar-height, 0px) + 16px);
+}

--- a/resources/views/admin/event-categories/show.blade.php
+++ b/resources/views/admin/event-categories/show.blade.php
@@ -164,7 +164,7 @@
             <form action="{{ route('admin.event-categories.sub-categories.store', $eventCategory) }}" method="POST"
                 class="row g-4 mb-6">
                 @csrf
-                <div class="col-md-3">
+                <div class="col-md-2">
                     <label class="required form-label">Name</label>
                     <input type="text" name="name" class="form-control form-control-solid"
                         value="{{ old('name') }}" placeholder="Kumite -55kg">
@@ -173,6 +173,16 @@
                     @enderror
                 </div>
                 <div class="col-md-2">
+                    <label class="required form-label">Type</label>
+                    <select name="category_type" class="form-select form-select-solid">
+                        <option value="individu">Individu</option>
+                        <option value="beregu">Beregu</option>
+                    </select>
+                    @error('category_type')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-1">
                     <label class="required form-label">Gender</label>
                     <select name="gender" class="form-select form-select-solid">
                         <option value="M">M</option>
@@ -191,23 +201,31 @@
                         <span class="text-danger small">{{ $message }}</span>
                     @enderror
                 </div>
-                <div class="col-md-2">
-                    <label class="required form-label">Min Participants</label>
+                <div class="col-md-1">
+                    <label class="required form-label">Min</label>
                     <input type="number" name="min_participants" class="form-control form-control-solid"
                         value="{{ old('min_participants', 1) }}" min="1">
                     @error('min_participants')
                         <span class="text-danger small">{{ $message }}</span>
                     @enderror
                 </div>
-                <div class="col-md-2">
-                    <label class="required form-label">Max Participants</label>
+                <div class="col-md-1">
+                    <label class="required form-label">Max</label>
                     <input type="number" name="max_participants" class="form-control form-control-solid"
                         value="{{ old('max_participants', 1) }}" min="1">
                     @error('max_participants')
                         <span class="text-danger small">{{ $message }}</span>
                     @enderror
                 </div>
-                <div class="col-md-1 d-flex align-items-end">
+                <div class="col-md-1">
+                    <label class="required form-label">Max Tim</label>
+                    <input type="number" name="max_teams" class="form-control form-control-solid"
+                        value="{{ old('max_teams', 1) }}" min="1">
+                    @error('max_teams')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+                <div class="col-md-2 d-flex align-items-end">
                     <button type="submit" class="btn btn-primary w-100">Tambah</button>
                 </div>
             </form>
@@ -220,6 +238,7 @@
                             <th>Gender</th>
                             <th>Price</th>
                             <th>Peserta</th>
+                            <th>Max Tim</th>
                             <th>Label</th>
                             <th class="text-end">Actions</th>
                         </tr>
@@ -231,6 +250,7 @@
                                 <td>{{ $subCategory->gender->value }}</td>
                                 <td>{{ number_format($subCategory->price, 2, ',', '.') }}</td>
                                 <td>{{ $subCategory->min_participants }} - {{ $subCategory->max_participants }}</td>
+                                <td>{{ $subCategory->max_teams }}</td>
                                 <td><span
                                         class="badge {{ $subCategory->isTeam() ? 'badge-light-primary' : 'badge-light-secondary' }}">{{ $subCategory->labelType() }}</span>
                                 </td>
@@ -276,6 +296,8 @@
                                 <div class="k-card-row"><span class="k-card-lbl">Peserta</span><span
                                         class="k-card-val">{{ $subCategory->min_participants }} -
                                         {{ $subCategory->max_participants }}</span></div>
+                                <div class="k-card-row"><span class="k-card-lbl">Max Tim</span><span
+                                        class="k-card-val">{{ $subCategory->max_teams }}</span></div>
                             </div>
                             <div class="k-card-acts">
                                 <a href="{{ route('admin.sub-categories.edit', $subCategory) }}"

--- a/resources/views/admin/sub-categories/edit.blade.php
+++ b/resources/views/admin/sub-categories/edit.blade.php
@@ -13,7 +13,7 @@
             </div>
             <div class="card-body py-5">
                 <div class="row g-4">
-                    <div class="col-md-4">
+                    <div class="col-md-3">
                         <label class="required form-label">Name</label>
                         <input type="text" name="name" class="form-control form-control-solid"
                             value="{{ old('name', $subCategory->name) }}">
@@ -22,6 +22,16 @@
                         @enderror
                     </div>
                     <div class="col-md-2">
+                        <label class="required form-label">Type</label>
+                        <select name="category_type" class="form-select form-select-solid">
+                            <option value="individu" @selected(old('category_type', $subCategory->category_type) === 'individu')>Individu</option>
+                            <option value="beregu" @selected(old('category_type', $subCategory->category_type) === 'beregu')>Beregu</option>
+                        </select>
+                        @error('category_type')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-1">
                         <label class="required form-label">Gender</label>
                         <select name="gender" class="form-select form-select-solid">
                             <option value="M" @selected(old('gender', $subCategory->gender->value) === 'M')>M</option>
@@ -44,19 +54,27 @@
                             <span class="text-danger small">{{ $message }}</span>
                         @enderror
                     </div>
-                    <div class="col-md-2">
-                        <label class="required form-label">Min Participants</label>
+                    <div class="col-md-1">
+                        <label class="required form-label">Min</label>
                         <input type="number" name="min_participants" class="form-control form-control-solid"
                             value="{{ old('min_participants', $subCategory->min_participants) }}" min="1">
                         @error('min_participants')
                             <span class="text-danger small">{{ $message }}</span>
                         @enderror
                     </div>
-                    <div class="col-md-2">
-                        <label class="required form-label">Max Participants</label>
+                    <div class="col-md-1">
+                        <label class="required form-label">Max</label>
                         <input type="number" name="max_participants" class="form-control form-control-solid"
                             value="{{ old('max_participants', $subCategory->max_participants) }}" min="1">
                         @error('max_participants')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="col-md-1">
+                        <label class="required form-label">Max Tim</label>
+                        <input type="number" name="max_teams" class="form-control form-control-solid"
+                            value="{{ old('max_teams', $subCategory->max_teams) }}" min="1">
+                        @error('max_teams')
                             <span class="text-danger small">{{ $message }}</span>
                         @enderror
                     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,6 +11,7 @@
 
     <link href="{{ asset('assets/plugins/global/plugins.bundle.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ asset('assets/css/style.bundle.css') }}" rel="stylesheet" type="text/css" />
+    @vite(['resources/css/registration.css'])
     @livewireStyles
 </head>
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,18 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    
+                    @can('view participants')
+                    <x-nav-link :href="route('participants.index')" :active="request()->routeIs('participants.*')">
+                        {{ __('Bank Peserta') }}
+                    </x-nav-link>
+                    @endcan
+
+                    @can('create registrations')
+                    <x-nav-link :href="route('registration.index')" :active="request()->routeIs('registration.index') || request()->routeIs('registration.create') || request()->routeIs('registration.invoice')">
+                        {{ __('Pendaftaran Atlet') }}
+                    </x-nav-link>
+                    @endcan
                 </div>
             </div>
 
@@ -70,6 +82,18 @@
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
+
+            @can('view participants')
+            <x-responsive-nav-link :href="route('participants.index')" :active="request()->routeIs('participants.*')">
+                {{ __('Bank Peserta') }}
+            </x-responsive-nav-link>
+            @endcan
+
+            @can('create registrations')
+            <x-responsive-nav-link :href="route('registration.index')" :active="request()->routeIs('registration.index') || request()->routeIs('registration.create') || request()->routeIs('registration.invoice')">
+                {{ __('Pendaftaran Atlet') }}
+            </x-responsive-nav-link>
+            @endcan
         </div>
 
         <!-- Responsive Settings Options -->

--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -167,12 +167,21 @@
                         </span>
                         <div class="menu-sub menu-sub-accordion">
                             <div class="menu-item">
-                                <a class="menu-link {{ request()->routeIs('registration.index') || request()->routeIs('registration.create') || request()->routeIs('registration.invoice') ? 'active' : '' }}"
+                                <a class="menu-link {{ request()->routeIs('registration.index') || request()->routeIs('registration.create') ? 'active' : '' }}"
                                     href="{{ route('registration.index') }}">
                                     <span class="menu-bullet">
                                         <span class="bullet bullet-dot"></span>
                                     </span>
                                     <span class="menu-title">Pendaftaran Atlet</span>
+                                </a>
+                            </div>
+                            <div class="menu-item">
+                                <a class="menu-link {{ request()->routeIs('registration.coaches') ? 'active' : '' }}"
+                                    href="{{ route('registration.coaches') }}">
+                                    <span class="menu-bullet">
+                                        <span class="bullet bullet-dot"></span>
+                                    </span>
+                                    <span class="menu-title">Pendaftaran Pelatih</span>
                                 </a>
                             </div>
                         </div>

--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -158,12 +158,24 @@
                 @endrole
 
                 @can('create registrations')
-                    <div class="menu-item">
-                        <a class="menu-link {{ request()->routeIs('registration.*') ? 'active' : '' }}"
-                            href="{{ route('registration.index') }}">
+                    <div data-kt-menu-trigger="click"
+                        class="menu-item menu-accordion {{ request()->routeIs('registration.*') ? 'hover show' : '' }}">
+                        <span class="menu-link">
                             <span class="menu-icon"><i class="bi bi-journal-text fs-3"></i></span>
-                            <span class="menu-title">Pendaftaran Event</span>
-                        </a>
+                            <span class="menu-title">Pendaftaran</span>
+                            <span class="menu-arrow"></span>
+                        </span>
+                        <div class="menu-sub menu-sub-accordion">
+                            <div class="menu-item">
+                                <a class="menu-link {{ request()->routeIs('registration.index') || request()->routeIs('registration.create') || request()->routeIs('registration.invoice') ? 'active' : '' }}"
+                                    href="{{ route('registration.index') }}">
+                                    <span class="menu-bullet">
+                                        <span class="bullet bullet-dot"></span>
+                                    </span>
+                                    <span class="menu-title">Pendaftaran Atlet</span>
+                                </a>
+                            </div>
+                        </div>
                     </div>
                 @endcan
 

--- a/resources/views/livewire/athlete-selection-form.blade.php
+++ b/resources/views/livewire/athlete-selection-form.blade.php
@@ -44,6 +44,13 @@
         @include('partials.error-alert', ['message' => $errorMessage])
     @endif
 
+    @if ($showSavedIndicator)
+        <div class="alert alert-success d-flex align-items-center p-4 mb-6">
+            <i class="fas fa-check-circle fs-2 text-success me-3"></i>
+            <div class="text-success fw-bold">Tersimpan</div>
+        </div>
+    @endif
+
     @php
         $selectedCount = count($selectedAthleteIds);
         $maxParticipants = $this->subCategory->max_participants;
@@ -100,7 +107,7 @@
                                 <div
                                     class="form-check form-check-solid form-check-custom form-check-success form-switch">
                                     <input class="form-check-input w-45px h-25px" type="checkbox"
-                                        wire:model="selectedAthleteIds" value="{{ $athlete->id }}"
+                                        wire:model.live="selectedAthleteIds" value="{{ $athlete->id }}"
                                         id="athlete_{{ $athlete->id }}"
                                         {{ !$isSelected && $isLimitReached ? 'disabled' : '' }}>
                                     <label class="form-check-label" for="athlete_{{ $athlete->id }}"></label>
@@ -213,96 +220,17 @@
                     @endif
 
                     <div class="d-flex flex-column gap-4">
-                        <button wire:click="confirmSubmit" wire:loading.attr="disabled"
-                            {{ count($selectedAthleteIds) < $this->subCategory->min_participants || count($selectedAthleteIds) > $this->subCategory->max_participants ? 'disabled' : '' }}
-                            class="btn btn-primary w-100 fw-bolder">
-                            <span wire:loading.remove wire:target="submit">
-                                @if (count($selectedAthleteIds) === 0)
-                                    Pilih atlet terlebih dahulu
-                                @elseif(count($selectedAthleteIds) < $this->subCategory->min_participants)
-                                    Pilih minimal {{ $this->subCategory->min_participants }} atlet
-                                @else
-                                    <i class="fas fa-arrow-right me-2"></i> Lanjutkan
-                                @endif
-                            </span>
-                            <span wire:loading wire:target="submit">
-                                <span class="spinner-border spinner-border-sm align-middle ms-2"></span> Memproses...
-                            </span>
-                        </button>
-
                         <a href="{{ route('registration.index') }}" wire:navigate
-                            class="btn btn-light-danger w-100 fw-bold">
-                            Batalkan
+                            class="btn btn-primary w-100 fw-bolder">
+                            Kembali ke Pendaftaran
+                        </a>
+                        <a href="{{ route('registration.invoice', ['event' => $eventId]) }}" wire:navigate
+                            class="btn btn-light-primary w-100 fw-bolder">
+                            Lanjut ke Invoice
                         </a>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-
-    {{-- Confirmation Modal --}}
-    <div class="modal fade {{ $showConfirmation ? 'show d-block' : '' }}" tabindex="-1"
-        aria-hidden="{{ !$showConfirmation }}">
-        <div class="modal-dialog modal-dialog-centered">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h3 class="modal-title fw-bolder">Konfirmasi Pendaftaran</h3>
-                    <button type="button" class="btn btn-icon btn-sm btn-active-light-primary"
-                        wire:click="cancelConfirmation">
-                        <i class="fas fa-times"></i>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <div class="mb-6">
-                        <div class="text-muted fw-bold fs-6 mb-2">SUB-KATEGORI</div>
-                        <div class="fw-bolder fs-5 text-dark">{{ $this->subCategory->name }}</div>
-                        <div class="text-muted fs-7 mt-1">
-                            {{ $this->subCategory->eventCategory->event->name }}
-                            <span class="mx-1">&bull;</span>
-                            {{ $this->subCategory->eventCategory->class_name }}
-                            <span class="mx-1">&bull;</span>
-                            {{ $this->subCategory->gender->value === 'M' ? 'Putra' : ($this->subCategory->gender->value === 'F' ? 'Putri' : 'Campuran') }}
-                        </div>
-                    </div>
-
-                    <div class="mb-6">
-                        <div class="text-muted fw-bold fs-6 mb-2">ATLET ({{ count($selectedAthleteIds) }})</div>
-                        @foreach ($this->eligibleAthletes->whereIn('id', $selectedAthleteIds) as $athlete)
-                            <div class="d-flex align-items-center mb-1">
-                                <i class="fas fa-check text-success me-2"></i>
-                                <span class="text-gray-700">{{ $athlete->name }}</span>
-                            </div>
-                        @endforeach
-                    </div>
-
-                    <div class="separator separator-dashed my-5"></div>
-
-                    <div class="d-flex flex-stack">
-                        <span class="text-gray-600 fw-bold fs-5">Total Biaya:</span>
-                        <span class="fw-bolder fs-3 text-primary">
-                            Rp {{ number_format($this->subCategory->price * count($selectedAthleteIds), 0, ',', '.') }}
-                        </span>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" wire:click="cancelConfirmation" class="btn btn-light fw-bold">
-                        Kembali
-                    </button>
-                    <button type="button" wire:click="submit" wire:loading.attr="disabled"
-                        class="btn btn-primary fw-bolder">
-                        <span wire:loading.remove wire:target="submit">
-                            <i class="fas fa-check me-2"></i> Konfirmasi
-                        </span>
-                        <span wire:loading wire:target="submit">
-                            <span class="spinner-border spinner-border-sm align-middle ms-2"></span> Memproses...
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    @if ($showConfirmation)
-        <div class="modal-backdrop fade show"></div>
-    @endif
 </div>

--- a/resources/views/livewire/athlete-selection-form.blade.php
+++ b/resources/views/livewire/athlete-selection-form.blade.php
@@ -58,72 +58,211 @@
 
     <div class="row g-8">
         <div class="col-xl-8">
-            {{-- Search Input --}}
-            <div class="mb-4">
-                <div class="input-group input-group-solid">
-                    <span class="input-group-text"><i class="fas fa-search text-muted"></i></span>
-                    <input type="text" wire:model.live="search" class="form-control form-control-solid"
-                        placeholder="Cari nama atlet..." autofocus>
+            @if ($this->subCategory->isTeam())
+                {{-- === MODE BEREGU === --}}
+                <div class="mb-6 d-flex align-items-center justify-content-between">
+                    <div>
+                        <h3 class="fw-bolder text-dark mb-0">Manajemen Tim</h3>
+                        <span class="text-muted fs-7">Buat tim dan masukkan atlet ke dalam tim.</span>
+                    </div>
+                    @php
+                        $canAddTeam = count($teams) < $this->subCategory->max_teams;
+                    @endphp
+                    <button wire:click="createTeam" class="btn btn-primary fw-bolder"
+                        {{ !$canAddTeam ? 'disabled' : '' }}>
+                        <i class="fas fa-plus me-2"></i>
+                        Tambah Tim ({{ count($teams) }}/{{ $this->subCategory->max_teams }})
+                    </button>
                 </div>
-            </div>
 
-            {{-- Daftar Atlet Eligible (Checkbox) --}}
-            <div class="card shadow-sm mb-8">
-                <div class="card-header border-0 pt-6">
-                    <h3 class="card-title align-items-start flex-column">
-                        <span class="card-label fw-bolder fs-3 text-success">
-                            <i class="fas fa-check-circle text-success me-2"></i> Atlet Memenuhi Syarat
-                        </span>
-                        <span class="text-muted mt-1 fw-bold fs-7">{{ $this->eligibleAthletes->count() }} atlet
-                            tersedia</span>
-                    </h3>
-                </div>
-                <div class="card-body pt-4">
-                    @forelse($this->eligibleAthletes as $athlete)
-                        @php
-                            $isSelected = in_array($athlete->id, $selectedAthleteIds, true);
-                            $isLimitReached = $selectedCount >= $maxParticipants;
-                        @endphp
-                        <label wire:key="athlete-{{ $athlete->id }}"
-                            class="d-flex flex-stack mb-4 cursor-pointer bg-hover-light p-3 rounded border border-dashed border-gray-300">
-
-                            <div class="d-flex align-items-center">
-                                <div class="symbol symbol-50px me-5">
-                                    <img src="{{ $athlete->photo_url }}" alt="{{ $athlete->name }}"
-                                        class="border border-gray-200 athlete-photo">
-                                </div>
-                                <div class="d-flex flex-column">
-                                    <span
-                                        class="fw-bolder text-gray-800 text-hover-primary fs-5">{{ $athlete->name }}</span>
-                                    <span class="text-muted fw-bold fs-7">
-                                        {{ $athlete->gender->value === 'M' ? 'Putra' : 'Putri' }}
-                                        <span class="mx-1">&bull;</span> Lahir:
-                                        {{ $athlete->birth_date->format('d/m/Y') }}
+                @forelse($teams as $team)
+                    <div wire:key="team-{{ $team['id'] }}"
+                        class="card shadow-sm mb-4 border {{ $activeTeamId === $team['id'] ? 'border-primary border-dashed' : 'border-gray-300' }}">
+                        <div class="card-header cursor-pointer py-4" wire:click="selectTeam({{ $team['id'] }})">
+                            <div class="card-title">
+                                <span class="symbol symbol-35px me-3">
+                                    <span class="symbol-label bg-light-primary text-primary fw-bold">
+                                        {{ $team['number'] }}
                                     </span>
-                                </div>
+                                </span>
+                                <h3 class="fw-bolder mb-0">{{ $team['name'] }}</h3>
                             </div>
-
-                            <div class="d-flex justify-content-end align-items-center">
-                                <div
-                                    class="form-check form-check-solid form-check-custom form-check-success form-switch">
-                                    <input class="form-check-input w-45px h-25px" type="checkbox"
-                                        wire:model.live="selectedAthleteIds" value="{{ $athlete->id }}"
-                                        id="athlete_{{ $athlete->id }}"
-                                        {{ !$isSelected && $isLimitReached ? 'disabled' : '' }}>
-                                    <label class="form-check-label" for="athlete_{{ $athlete->id }}"></label>
-                                </div>
-                            </div>
-                        </label>
-                    @empty
-                        <div class="text-center py-10 bg-light-secondary rounded border border-dashed">
-                            <i class="fas fa-box-open fs-3x text-muted mb-4"></i>
-                            <div class="fs-5 fw-bold text-gray-600">
-                                {{ $search ? 'Tidak ditemukan atlet yang sesuai pencarian.' : 'Tidak ada atlet yang memenuhi syarat untuk sub-kategori ini.' }}
+                            <div class="card-toolbar">
+                                <span
+                                    class="badge {{ count($team['memberIds']) >= $this->subCategory->min_participants ? 'badge-light-success' : 'badge-light-warning' }} fw-bolder fs-7 px-4 py-3">
+                                    {{ count($team['memberIds']) }}/{{ $this->subCategory->max_participants }} Atlet
+                                </span>
+                                <i
+                                    class="fas fa-chevron-{{ $activeTeamId === $team['id'] ? 'up' : 'down' }} ms-4 text-gray-400"></i>
                             </div>
                         </div>
-                    @endforelse
+
+                        @if ($activeTeamId === $team['id'])
+                            <div class="card-body py-5">
+                                {{-- Search & Filter for Team Mode --}}
+                                <div class="mb-5">
+                                    <div class="input-group input-group-sm input-group-solid">
+                                        <span class="input-group-text"><i class="fas fa-search text-muted"></i></span>
+                                        <input type="text" wire:model.live="search" class="form-control"
+                                            placeholder="Cari nama atlet...">
+                                    </div>
+                                </div>
+
+                                <div class="row g-4">
+                                    @forelse($this->eligibleAthletes as $athlete)
+                                        @php
+                                            $isInThisTeam = in_array($athlete->id, $team['memberIds']);
+                                            $isInOtherTeam = !$isInThisTeam && $this->isAthleteInAnyTeam($athlete->id);
+                                            $isFull = count($team['memberIds']) >= $this->subCategory->max_participants;
+                                        @endphp
+                                        <div class="col-md-6">
+                                            <label
+                                                class="d-flex flex-stack p-4 rounded border border-dashed {{ $isInOtherTeam ? 'bg-light opacity-50' : 'bg-hover-light cursor-pointer' }} {{ $isInThisTeam ? 'border-primary bg-light-primary' : 'border-gray-300' }}">
+                                                <div class="d-flex align-items-center">
+                                                    <div class="symbol symbol-35px me-3">
+                                                        <img src="{{ $athlete->photo_url }}" alt="{{ $athlete->name }}">
+                                                    </div>
+                                                    <div class="d-flex flex-column">
+                                                        <span
+                                                            class="fw-bold text-gray-800 fs-7">{{ $athlete->name }}</span>
+                                                        @if ($isInOtherTeam)
+                                                            <span class="badge badge-light-danger fs-9 px-1">Sudah di tim
+                                                                lain</span>
+                                                        @endif
+                                                    </div>
+                                                </div>
+                                                <div class="form-check form-check-solid form-switch">
+                                                    <input type="checkbox" class="form-check-input h-20px w-35px"
+                                                        wire:click="toggleTeamMember({{ $athlete->id }})"
+                                                        {{ $isInThisTeam ? 'checked' : '' }}
+                                                        {{ $isInOtherTeam || (!$isInThisTeam && $isFull) ? 'disabled' : '' }}>
+                                                </div>
+                                            </label>
+                                        </div>
+                                    @empty
+                                        <div class="col-12 text-center py-5 text-muted">Tidak ada atlet tersedia</div>
+                                    @endforelse
+                                </div>
+                            </div>
+                            <div class="card-footer py-4 d-flex justify-content-end">
+                                <button wire:click="deleteTeam({{ $team['id'] }})"
+                                    wire:confirm="Hapus tim ini beserta semua anggotanya?"
+                                    class="btn btn-sm btn-light-danger fw-bolder">
+                                    <i class="fas fa-trash me-2"></i> Hapus Tim
+                                </button>
+                            </div>
+                        @endif
+                    </div>
+                @empty
+                    <div class="card shadow-sm border-dashed border-gray-400 bg-light-secondary">
+                        <div class="card-body text-center py-15">
+                            <i class="fas fa-users-cog fs-3x text-muted mb-5"></i>
+                            <h3 class="fw-bolder text-gray-700">Belum Ada Tim</h3>
+                            <p class="text-muted mb-6">Klik tombol "Tambah Tim" untuk mulai mendaftarkan atlet ke kategori
+                                beregu ini.</p>
+                            <button wire:click="createTeam" class="btn btn-primary fw-bolder">
+                                <i class="fas fa-plus me-2"></i> Buat Tim Pertama
+                            </button>
+                        </div>
+                    </div>
+                @endforelse
+            @else
+                {{-- === MODE INDIVIDU === --}}
+                {{-- Search Input --}}
+                <div class="mb-4">
+                    <div class="input-group input-group-solid">
+                        <span class="input-group-text"><i class="fas fa-search text-muted"></i></span>
+                        <input type="text" wire:model.live="search" class="form-control form-control-solid"
+                            placeholder="Cari nama atlet..." autofocus>
+                    </div>
                 </div>
-            </div>
+
+                {{-- Daftar Atlet Eligible (Checkbox) --}}
+                <div class="card shadow-sm mb-8">
+                    <div class="card-header border-0 pt-6">
+                        <h3 class="card-title align-items-start flex-column">
+                            <span class="card-label fw-bolder fs-3 text-success">
+                                <i class="fas fa-check-circle text-success me-2"></i> Atlet Memenuhi Syarat
+                            </span>
+                            <span class="text-muted mt-1 fw-bold fs-7">{{ $this->eligibleAthletes->count() }} atlet
+                                tersedia</span>
+                        </h3>
+                    </div>
+                    <div class="card-body pt-4">
+                        @forelse($this->eligibleAthletes as $athlete)
+                            @php
+                                $isSelected = in_array($athlete->id, $selectedAthleteIds, true);
+                                $isLimitReached = $selectedCount >= $maxParticipants;
+                            @endphp
+                            <label wire:key="athlete-{{ $athlete->id }}"
+                                class="d-flex flex-stack mb-4 cursor-pointer bg-hover-light p-3 rounded border border-dashed border-gray-300">
+
+                                <div class="d-flex align-items-center">
+                                    <div class="symbol symbol-50px me-5">
+                                        <img src="{{ $athlete->photo_url }}" alt="{{ $athlete->name }}"
+                                            class="border border-gray-200 athlete-photo">
+                                    </div>
+                                    <div class="d-flex flex-column">
+                                        <span
+                                            class="fw-bolder text-gray-800 text-hover-primary fs-5">{{ $athlete->name }}</span>
+
+                                        {{-- Registration Preview Badges --}}
+                                        <div class="d-flex flex-wrap gap-1 mt-1 mb-1">
+                                            @php
+                                                $otherRegs = collect();
+                                                foreach ($athlete->draftItems as $item) {
+                                                    if ($item->sub_category_id && $item->sub_category_id !== $this->subCategoryId) {
+                                                        $otherRegs->push(['name' => $item->subCategory->name, 'type' => 'draft']);
+                                                    }
+                                                }
+                                                foreach ($athlete->registrations as $reg) {
+                                                    if ($reg->sub_category_id && $reg->sub_category_id !== $this->subCategoryId) {
+                                                        $otherRegs->push(['name' => $reg->subCategory->name, 'type' => 'active']);
+                                                    }
+                                                }
+                                            @endphp
+
+                                            @forelse($otherRegs as $reg)
+                                                <span class="badge badge-light-{{ $reg['type'] === 'active' ? 'success' : 'info' }} fw-bold fs-9 py-1 px-2"
+                                                    title="{{ $reg['type'] === 'active' ? 'Sudah Terdaftar (Invoice)' : 'Dalam Draf' }}">
+                                                    {{ $reg['name'] }}
+                                                </span>
+                                            @empty
+                                                <span class="text-muted fs-8 fst-italic">Belum terdaftar di kategori
+                                                    lain</span>
+                                            @endforelse
+                                        </div>
+
+                                        <span class="text-muted fw-bold fs-7">
+                                            {{ $athlete->gender->value === 'M' ? 'Putra' : 'Putri' }}
+                                            <span class="mx-1">&bull;</span> Lahir:
+                                            {{ $athlete->birth_date->format('d/m/Y') }}
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div class="d-flex justify-content-end align-items-center">
+                                    <div
+                                        class="form-check form-check-solid form-check-custom form-check-success form-switch">
+                                        <input class="form-check-input w-45px h-25px" type="checkbox"
+                                            wire:model.live="selectedAthleteIds" value="{{ $athlete->id }}"
+                                            id="athlete_{{ $athlete->id }}"
+                                            {{ !$isSelected && $isLimitReached ? 'disabled' : '' }}>
+                                        <label class="form-check-label" for="athlete_{{ $athlete->id }}"></label>
+                                    </div>
+                                </div>
+                            </label>
+                        @empty
+                            <div class="text-center py-10 bg-light-secondary rounded border border-dashed">
+                                <i class="fas fa-box-open fs-3x text-muted mb-4"></i>
+                                <div class="fs-5 fw-bold text-gray-600">
+                                    {{ $search ? 'Tidak ditemukan atlet yang sesuai pencarian.' : 'Tidak ada atlet yang memenuhi syarat untuk sub-kategori ini.' }}
+                                </div>
+                            </div>
+                        @endforelse
+                    </div>
+                </div>
+            @endif
 
             {{-- Toggle & Daftar Atlet TIDAK Eligible --}}
             @if ($this->ineligibleAthletes->count() > 0)
@@ -156,6 +295,33 @@
                                             </div>
                                             <div class="d-flex flex-column">
                                                 <span class="fw-bolder text-gray-600 fs-6">{{ $athlete->name }}</span>
+
+                                                {{-- Registration Preview Badges --}}
+                                                <div class="d-flex flex-wrap gap-1 mt-1 mb-1">
+                                                    @php
+                                                        $otherRegs = collect();
+                                                        foreach ($athlete->draftItems as $item) {
+                                                            if ($item->sub_category_id && $item->sub_category_id !== $this->subCategoryId) {
+                                                                $otherRegs->push(['name' => $item->subCategory->name, 'type' => 'draft']);
+                                                            }
+                                                        }
+                                                        foreach ($athlete->registrations as $reg) {
+                                                            if ($reg->sub_category_id && $reg->sub_category_id !== $this->subCategoryId) {
+                                                                $otherRegs->push(['name' => $reg->subCategory->name, 'type' => 'active']);
+                                                            }
+                                                        }
+                                                    @endphp
+
+                                                    @forelse($otherRegs as $reg)
+                                                        <span class="badge badge-light-{{ $reg['type'] === 'active' ? 'success' : 'info' }} fw-bold fs-9 py-1 px-2"
+                                                            title="{{ $reg['type'] === 'active' ? 'Sudah Terdaftar (Invoice)' : 'Dalam Draf' }}">
+                                                            {{ $reg['name'] }}
+                                                        </span>
+                                                    @empty
+                                                        <span class="text-muted fs-8 fst-italic">Belum terdaftar</span>
+                                                    @endforelse
+                                                </div>
+
                                                 <span
                                                     class="text-danger fw-bold fs-8">{{ $athlete->ineligible_reason }}</span>
                                             </div>
@@ -175,48 +341,88 @@
                     <h3 class="card-title fw-bolder">Ringkasan</h3>
                 </div>
                 <div class="card-body">
-                    <div class="d-flex flex-stack mb-5">
-                        <span class="text-gray-600 fw-bold fs-5">Total Terpilih:</span>
-                        <span class="fw-bolder fs-3">
-                            <span
-                                class="{{ count($selectedAthleteIds) === 0 ? 'text-danger' : (count($selectedAthleteIds) < $this->subCategory->min_participants ? 'text-warning' : 'text-success') }}">
-                                {{ count($selectedAthleteIds) }}
+                    @if ($this->subCategory->isTeam())
+                        {{-- Ringkasan Mode Beregu --}}
+                        <div class="d-flex flex-stack mb-5">
+                            <span class="text-gray-600 fw-bold fs-5">Total Tim:</span>
+                            <span class="fw-bolder fs-3">
+                                <span class="{{ count($teams) === 0 ? 'text-danger' : 'text-success' }}">
+                                    {{ count($teams) }}
+                                </span>
+                                <span class="text-muted fs-6">/ {{ $this->subCategory->max_teams }}</span>
                             </span>
-                            <span class="text-muted fs-6">/ {{ $this->subCategory->max_participants }}</span>
-                        </span>
-                    </div>
-
-                    @if (count($selectedAthleteIds) > 0 && count($selectedAthleteIds) < $this->subCategory->min_participants)
-                        <div class="notice d-flex bg-light-warning rounded p-3 mb-5">
-                            <i class="fas fa-info-circle text-warning me-3 mt-1"></i>
-                            <span class="fs-7 text-gray-700">Pilih minimal
-                                {{ $this->subCategory->min_participants - count($selectedAthleteIds) }} atlet
-                                lagi</span>
                         </div>
-                    @endif
 
-                    <div class="separator separator-dashed my-6"></div>
-
-                    {{-- Selected athletes preview --}}
-                    @if (count($selectedAthleteIds) > 0)
-                        <div class="mb-5">
-                            <div class="text-muted fw-bold fs-7 mb-2">ATLET TERPILIH</div>
-                            @foreach ($this->eligibleAthletes->whereIn('id', $selectedAthleteIds) as $athlete)
-                                <div class="d-flex align-items-center mb-1">
-                                    <i class="fas fa-user-check text-success fs-6 me-2"></i>
-                                    <span class="text-gray-700 fs-7">{{ $athlete->name }}</span>
+                        @foreach ($teams as $team)
+                            <div class="mb-4 p-3 bg-light rounded border border-dashed {{ $activeTeamId === $team['id'] ? 'border-primary' : 'border-gray-300' }}">
+                                <div class="d-flex flex-stack mb-1">
+                                    <span class="fw-bolder text-gray-800">{{ $team['name'] }}</span>
+                                    <span class="badge {{ count($team['memberIds']) >= $this->subCategory->min_participants ? 'badge-light-success' : 'badge-light-warning' }} fs-9">
+                                        {{ count($team['memberIds']) }}/{{ $this->subCategory->max_participants }}
+                                    </span>
                                 </div>
-                            @endforeach
-                        </div>
-                        <div class="separator separator-dashed my-5"></div>
+                                <div class="text-muted fs-8">
+                                    @php
+                                        $members = $this->eligibleAthletes->whereIn('id', $team['memberIds'])->pluck('name');
+                                    @endphp
+                                    {{ $members->isNotEmpty() ? $members->join(', ') : 'Belum ada anggota' }}
+                                </div>
+                            </div>
+                        @endforeach
+
+                        <div class="separator separator-dashed my-6"></div>
 
                         <div class="d-flex flex-stack mb-5">
-                            <span class="text-gray-600 fw-bold fs-6">Biaya:</span>
-                            <span class="fw-bolder fs-4 text-dark">
-                                Rp
-                                {{ number_format($this->subCategory->price * count($selectedAthleteIds), 0, ',', '.') }}
+                            <span class="text-gray-600 fw-bold fs-6">Biaya (Flat per Tim):</span>
+                            <span class="fw-bolder fs-4 text-dark text-end">
+                                {{ count($teams) }} × Rp {{ number_format($this->subCategory->price, 0, ',', '.') }}<br>
+                                <span class="fs-3 text-primary">= Rp {{ number_format($this->subCategory->price * count($teams), 0, ',', '.') }}</span>
                             </span>
                         </div>
+                    @else
+                        {{-- Ringkasan Mode Individu --}}
+                        <div class="d-flex flex-stack mb-5">
+                            <span class="text-gray-600 fw-bold fs-5">Total Terpilih:</span>
+                            <span class="fw-bolder fs-3">
+                                <span
+                                    class="{{ count($selectedAthleteIds) === 0 ? 'text-danger' : (count($selectedAthleteIds) < $this->subCategory->min_participants ? 'text-warning' : 'text-success') }}">
+                                    {{ count($selectedAthleteIds) }}
+                                </span>
+                                <span class="text-muted fs-6">/ {{ $this->subCategory->max_participants }}</span>
+                            </span>
+                        </div>
+
+                        @if (count($selectedAthleteIds) > 0 && count($selectedAthleteIds) < $this->subCategory->min_participants)
+                            <div class="notice d-flex bg-light-warning rounded p-3 mb-5">
+                                <i class="fas fa-info-circle text-warning me-3 mt-1"></i>
+                                <span class="fs-7 text-gray-700">Pilih minimal
+                                    {{ $this->subCategory->min_participants - count($selectedAthleteIds) }} atlet
+                                    lagi</span>
+                            </div>
+                        @endif
+
+                        <div class="separator separator-dashed my-6"></div>
+
+                        {{-- Selected athletes preview --}}
+                        @if (count($selectedAthleteIds) > 0)
+                            <div class="mb-5">
+                                <div class="text-muted fw-bold fs-7 mb-2">ATLET TERPILIH</div>
+                                @foreach ($this->eligibleAthletes->whereIn('id', $selectedAthleteIds) as $athlete)
+                                    <div class="d-flex align-items-center mb-1">
+                                        <i class="fas fa-user-check text-success fs-6 me-2"></i>
+                                        <span class="text-gray-700 fs-7">{{ $athlete->name }}</span>
+                                    </div>
+                                @endforeach
+                            </div>
+                            <div class="separator separator-dashed my-5"></div>
+
+                            <div class="d-flex flex-stack mb-5">
+                                <span class="text-gray-600 fw-bold fs-6">Biaya:</span>
+                                <span class="fw-bolder fs-4 text-dark text-end">
+                                    Rp {{ number_format($this->subCategory->price * count($selectedAthleteIds), 0, ',', '.') }}
+                                </span>
+                            </div>
+                        @endif
                     @endif
 
                     <div class="d-flex flex-column gap-4">
@@ -228,6 +434,12 @@
                             class="btn btn-light-primary w-100 fw-bolder">
                             Lanjut ke Invoice
                         </a>
+                        
+                        <button type="button" wire:click="clearDraft" 
+                            wire:confirm="Apakah Anda yakin ingin menghapus semua pilihan (atlet & pelatih) di draf untuk event ini?"
+                            class="btn btn-light-danger w-100 fw-bolder mt-2">
+                            <i class="bi bi-trash3 me-2"></i> Kosongkan Draf
+                        </button>
                     </div>
                 </div>
             </div>

--- a/resources/views/livewire/coach-selection-form.blade.php
+++ b/resources/views/livewire/coach-selection-form.blade.php
@@ -1,25 +1,13 @@
-<x-app-layout>
-    @section('title', 'Pendaftaran Pelatih')
+<div>
+    {{-- Header Info --}}
+    <div class="card shadow-sm mb-6">
+        <div class="card-body p-6">
+            <h2 class="fs-2 fw-bolder text-dark mb-1">
+                Pendaftaran Pelatih
+            </h2>
+            <p class="text-muted fw-bold fs-6 mb-5">Pilih event dan daftarkan pelatih kontingen Anda</p>
 
-    <div class="card mb-5">
-        <div class="card-header border-0 pt-5">
-            <h3 class="card-title align-items-start flex-column">
-                <span class="card-label fw-bold text-dark">Pendaftaran Pelatih</span>
-                <span class="text-muted mt-1 fw-semibold fs-7">Pilih event dan daftarkan pelatih kontingen Anda</span>
-            </h3>
-        </div>
-
-        <div class="card-body py-5">
-            {{-- Error Message --}}
-            @if ($errorMessage)
-                <div class="alert alert-danger d-flex align-items-center mb-7">
-                    <i class="bi bi-exclamation-triangle-fill fs-4 me-3"></i>
-                    <div>{{ $errorMessage }}</div>
-                </div>
-            @endif
-
-            {{-- Event Selection --}}
-            <div class="fv-row mb-7">
+            <div class="fv-row">
                 <label class="required form-label fs-6 fw-bold mb-3">Pilih Event</label>
                 <select class="form-select form-select-solid form-select-lg"
                         wire:model.live="selectedEventId">
@@ -31,83 +19,164 @@
                     @endforeach
                 </select>
             </div>
-
-            {{-- Coach List --}}
-            @if ($selectedEventId)
-                <div class="fv-row">
-                    <label class="form-label fs-6 fw-bold mb-3">Daftar Pelatih</label>
-
-                    @if ($this->coaches->count() > 0)
-                        @php
-                            $hasConfirmedCoaches = collect($this->coaches)->contains(fn($coach) => in_array($coach->id, $this->confirmedCoachIds));
-                        @endphp
-
-                        <div class="border rounded p-4 bg-light">
-                            @foreach ($this->coaches as $coach)
-                                @php
-                                    $isRegistered = in_array($coach->id, $this->registeredCoachIds);
-                                    $isConfirmed = in_array($coach->id, $this->confirmedCoachIds);
-                                @endphp
-
-                                <div class="d-flex align-items-center py-3 @if(!$loop->last) border-bottom @endif">
-                                    <div class="form-check form-check-solid form-check-custom me-4">
-                                        <input class="form-check-input"
-                                               type="checkbox"
-                                               value="{{ $coach->id }}"
-                                               wire:model.live="selectedCoachIds"
-                                               @if ($isConfirmed) disabled @endif
-                                               id="coach_{{ $coach->id }}" />
-                                    </div>
-
-                                    <div class="symbol symbol-50px symbol-circle me-4">
-                                        @if ($coach->photo)
-                                            <img src="{{ $coach->photo_url }}"
-                                                 alt="{{ $coach->name }}"
-                                                 class="object-fit-cover" />
-                                        @else
-                                            <div class="symbol-label bg-light-success text-success fs-3">
-                                                {{ strtoupper(substr($coach->name, 0, 1)) }}
-                                            </div>
-                                        @endif
-                                    </div>
-
-                                    <div class="flex-grow-1">
-                                        <div class="d-flex align-items-center mb-1">
-                                            <span class="fs-6 fw-bold text-gray-800 me-2">{{ $coach->name }}</span>
-                                            @if ($isRegistered && !$isConfirmed)
-                                                <span class="badge badge-light-success">Terdaftar</span>
-                                            @elseif ($isConfirmed)
-                                                <span class="badge badge-light-primary">Invoice Confirmed</span>
-                                            @endif
-                                        </div>
-                                        @if ($coach->nik)
-                                            <span class="text-muted fs-7">NIK: {{ $coach->nik }}</span>
-                                        @endif
-                                    </div>
-                                </div>
-                            @endforeach
-                        </div>
-
-                        @if ($hasConfirmedCoaches)
-                            <div class="form-text mt-2">
-                                <i class="bi bi-info-circle"></i>
-                                Pelatih yang sudah masuk invoice confirmed tidak dapat diubah.
-                            </div>
-                        @endif
-                    @else
-                        <div class="text-center text-muted py-10">
-                            <i class="bi bi-people fs-1 mb-3 d-block"></i>
-                            <span class="fw-semibold">Belum ada data pelatih</span>
-                            <p class="text-muted fs-7 mt-2">
-                                Silakan tambahkan pelatih terlebih dahulu di menu Bank Peserta.
-                            </p>
-                            <a href="{{ route('participants.create') }}" class="btn btn-light-primary btn-sm">
-                                <i class="bi bi-plus-lg me-1"></i> Tambah Pelatih
-                            </a>
-                        </div>
-                    @endif
-                </div>
-            @endif
         </div>
     </div>
-</x-app-layout>
+
+    {{-- Error Message --}}
+    @if ($errorMessage)
+        @include('partials.error-alert', ['message' => $errorMessage])
+    @endif
+
+    {{-- Saved Indicator --}}
+    @if ($showSavedIndicator)
+        <div class="alert alert-success d-flex align-items-center p-4 mb-6">
+            <i class="fas fa-check-circle fs-2 text-success me-3"></i>
+            <div class="text-success fw-bold">Tersimpan</div>
+        </div>
+    @endif
+
+    @if ($selectedEventId)
+        @php
+            $event = $this->selectedEvent;
+            $selectedCount = count($selectedCoachIds);
+        @endphp
+
+        <div class="row g-8">
+            <div class="col-xl-8">
+                {{-- Search Input --}}
+                <div class="mb-4">
+                    <div class="input-group input-group-solid">
+                        <span class="input-group-text"><i class="fas fa-search text-muted"></i></span>
+                        <input type="text" wire:model.live="search" class="form-control form-control-solid"
+                            placeholder="Cari nama pelatih..." autofocus>
+                    </div>
+                </div>
+
+                {{-- Daftar Pelatih --}}
+                <div class="card shadow-sm mb-8">
+                    <div class="card-header border-0 pt-6">
+                        <h3 class="card-title align-items-start flex-column">
+                            <span class="card-label fw-bolder fs-3 text-primary">
+                                <i class="fas fa-user-tie text-primary me-2"></i> Daftar Pelatih
+                            </span>
+                            <span class="text-muted mt-1 fw-bold fs-7">{{ $this->coaches->count() }} pelatih tersedia</span>
+                        </h3>
+                    </div>
+                    <div class="card-body pt-4">
+                        @forelse($this->coaches as $coach)
+                            @php
+                                $isRegistered = in_array($coach->id, $this->registeredCoachIds);
+                                $isConfirmed = in_array($coach->id, $this->confirmedCoachIds);
+                            @endphp
+                            <label wire:key="coach-{{ $coach->id }}"
+                                class="d-flex flex-stack mb-4 cursor-pointer bg-hover-light p-3 rounded border border-dashed border-gray-300">
+
+                                <div class="d-flex align-items-center">
+                                    <div class="symbol symbol-50px me-5">
+                                        <img src="{{ $coach->photo_url }}" alt="{{ $coach->name }}"
+                                            class="border border-gray-200 object-fit-cover">
+                                    </div>
+                                    <div class="d-flex flex-column">
+                                        <span class="fw-bolder text-gray-800 text-hover-primary fs-5">
+                                            {{ $coach->name }}
+                                        </span>
+                                        <div class="d-flex align-items-center mt-1">
+                                            @if ($coach->nik)
+                                                <span class="text-muted fw-bold fs-7 me-3">NIK: {{ $coach->nik }}</span>
+                                            @endif
+                                            @if ($isRegistered && !$isConfirmed)
+                                                <span class="badge badge-light-success fw-bolder">Terdaftar</span>
+                                            @elseif ($isConfirmed)
+                                                <span class="badge badge-light-primary fw-bolder">Invoice Confirmed</span>
+                                            @endif
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="d-flex justify-content-end align-items-center">
+                                    <div class="form-check form-check-solid form-check-custom form-check-success form-switch">
+                                        <input class="form-check-input w-45px h-25px" type="checkbox"
+                                            wire:model.live="selectedCoachIds" value="{{ $coach->id }}"
+                                            id="coach_{{ $coach->id }}"
+                                            @if ($isConfirmed) disabled @endif>
+                                        <label class="form-check-label" for="coach_{{ $coach->id }}"></label>
+                                    </div>
+                                </div>
+                            </label>
+                        @empty
+                            <div class="text-center py-10 bg-light-secondary rounded border border-dashed">
+                                <i class="fas fa-box-open fs-3x text-muted mb-4"></i>
+                                <div class="fs-5 fw-bold text-gray-600">
+                                    {{ $search ? 'Tidak ditemukan pelatih yang sesuai pencarian.' : 'Belum ada data pelatih. Silakan tambahkan pelatih di Bank Peserta.' }}
+                                </div>
+                                @if (!$search)
+                                    <div class="mt-4">
+                                        <a href="{{ route('participants.index') }}" class="btn btn-primary btn-sm">
+                                            <i class="fas fa-plus me-1"></i> Tambah Pelatih
+                                        </a>
+                                    </div>
+                                @endif
+                            </div>
+                        @endforelse
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-xl-4">
+                <div class="card shadow-sm sticky-summary">
+                    <div class="card-header">
+                        <h3 class="card-title fw-bolder">Ringkasan</h3>
+                    </div>
+                    <div class="card-body">
+                        <div class="d-flex flex-stack mb-5">
+                            <span class="text-gray-600 fw-bold fs-5">Pelatih Terpilih:</span>
+                            <span class="fw-bolder fs-3">
+                                <span class="{{ $selectedCount === 0 ? 'text-muted' : 'text-success' }}">
+                                    {{ $selectedCount }}
+                                </span>
+                            </span>
+                        </div>
+
+                        <div class="separator separator-dashed my-6"></div>
+
+                        {{-- Selected coaches preview --}}
+                        @if ($selectedCount > 0)
+                            <div class="mb-5">
+                                <div class="text-muted fw-bold fs-7 mb-2">PELATIH TERDAFTAR</div>
+                                @foreach ($this->coaches->whereIn('id', $selectedCoachIds) as $coach)
+                                    <div class="d-flex align-items-center mb-2">
+                                        <i class="fas fa-user-check text-success fs-6 me-2"></i>
+                                        <span class="text-gray-700 fs-7 fw-bold">{{ $coach->name }}</span>
+                                    </div>
+                                @endforeach
+                            </div>
+                            <div class="separator separator-dashed my-5"></div>
+
+                            <div class="d-flex flex-stack mb-5">
+                                <span class="text-gray-600 fw-bold fs-6">Biaya Pelatih:</span>
+                                <span class="fw-bolder fs-4 text-dark">
+                                    Rp {{ number_format($event->coach_fee * $selectedCount, 0, ',', '.') }}
+                                </span>
+                            </div>
+                            <div class="text-muted fs-8 mb-5">
+                                * Biaya per pelatih: Rp {{ number_format($event->coach_fee, 0, ',', '.') }}
+                            </div>
+                        @endif
+
+                        <div class="d-flex flex-column gap-4">
+                            <a href="{{ route('registration.index') }}" wire:navigate
+                                class="btn btn-primary w-100 fw-bolder">
+                                Kembali ke Pendaftaran
+                            </a>
+                            <a href="{{ route('registration.invoice', ['event' => $selectedEventId]) }}" wire:navigate
+                                class="btn btn-light-primary w-100 fw-bolder">
+                                Lanjut ke Invoice
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>
+

--- a/resources/views/livewire/coach-selection-form.blade.php
+++ b/resources/views/livewire/coach-selection-form.blade.php
@@ -1,0 +1,113 @@
+<x-app-layout>
+    @section('title', 'Pendaftaran Pelatih')
+
+    <div class="card mb-5">
+        <div class="card-header border-0 pt-5">
+            <h3 class="card-title align-items-start flex-column">
+                <span class="card-label fw-bold text-dark">Pendaftaran Pelatih</span>
+                <span class="text-muted mt-1 fw-semibold fs-7">Pilih event dan daftarkan pelatih kontingen Anda</span>
+            </h3>
+        </div>
+
+        <div class="card-body py-5">
+            {{-- Error Message --}}
+            @if ($errorMessage)
+                <div class="alert alert-danger d-flex align-items-center mb-7">
+                    <i class="bi bi-exclamation-triangle-fill fs-4 me-3"></i>
+                    <div>{{ $errorMessage }}</div>
+                </div>
+            @endif
+
+            {{-- Event Selection --}}
+            <div class="fv-row mb-7">
+                <label class="required form-label fs-6 fw-bold mb-3">Pilih Event</label>
+                <select class="form-select form-select-solid form-select-lg"
+                        wire:model.live="selectedEventId">
+                    <option value="">-- Pilih Event --</option>
+                    @foreach ($this->events as $event)
+                        <option value="{{ $event->id }}">
+                            {{ $event->name }} ({{ $event->event_date->format('d M Y') }})
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+
+            {{-- Coach List --}}
+            @if ($selectedEventId)
+                <div class="fv-row">
+                    <label class="form-label fs-6 fw-bold mb-3">Daftar Pelatih</label>
+
+                    @if ($this->coaches->count() > 0)
+                        @php
+                            $hasConfirmedCoaches = collect($this->coaches)->contains(fn($coach) => in_array($coach->id, $getConfirmedCoachIds()));
+                        @endphp
+
+                        <div class="border rounded p-4 bg-light">
+                            @foreach ($this->coaches as $coach)
+                                @php
+                                    $isRegistered = in_array($coach->id, $registeredCoachIds);
+                                    $isConfirmed = in_array($coach->id, $getConfirmedCoachIds());
+                                @endphp
+
+                                <div class="d-flex align-items-center py-3 @if(!$loop->last) border-bottom @endif">
+                                    <div class="form-check form-check-solid form-check-custom me-4">
+                                        <input class="form-check-input"
+                                               type="checkbox"
+                                               value="{{ $coach->id }}"
+                                               wire:model.live="selectedCoachIds"
+                                               @if ($isConfirmed) disabled @endif
+                                               id="coach_{{ $coach->id }}" />
+                                    </div>
+
+                                    <div class="symbol symbol-50px symbol-circle me-4">
+                                        @if ($coach->photo)
+                                            <img src="{{ $coach->photo_url }}"
+                                                 alt="{{ $coach->name }}"
+                                                 class="object-fit-cover" />
+                                        @else
+                                            <div class="symbol-label bg-light-success text-success fs-3">
+                                                {{ strtoupper(substr($coach->name, 0, 1)) }}
+                                            </div>
+                                        @endif
+                                    </div>
+
+                                    <div class="flex-grow-1">
+                                        <div class="d-flex align-items-center mb-1">
+                                            <span class="fs-6 fw-bold text-gray-800 me-2">{{ $coach->name }}</span>
+                                            @if ($isRegistered && !$isConfirmed)
+                                                <span class="badge badge-light-success">Terdaftar</span>
+                                            @elseif ($isConfirmed)
+                                                <span class="badge badge-light-primary">Invoice Confirmed</span>
+                                            @endif
+                                        </div>
+                                        @if ($coach->nik)
+                                            <span class="text-muted fs-7">NIK: {{ $coach->nik }}</span>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+
+                        @if ($hasConfirmedCoaches)
+                            <div class="form-text mt-2">
+                                <i class="bi bi-info-circle"></i>
+                                Pelatih yang sudah masuk invoice confirmed tidak dapat diubah.
+                            </div>
+                        @endif
+                    @else
+                        <div class="text-center text-muted py-10">
+                            <i class="bi bi-people fs-1 mb-3 d-block"></i>
+                            <span class="fw-semibold">Belum ada data pelatih</span>
+                            <p class="text-muted fs-7 mt-2">
+                                Silakan tambahkan pelatih terlebih dahulu di menu Bank Peserta.
+                            </p>
+                            <a href="{{ route('participants.create') }}" class="btn btn-light-primary btn-sm">
+                                <i class="bi bi-plus-lg me-1"></i> Tambah Pelatih
+                            </a>
+                        </div>
+                    @endif
+                </div>
+            @endif
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/livewire/coach-selection-form.blade.php
+++ b/resources/views/livewire/coach-selection-form.blade.php
@@ -172,6 +172,12 @@
                                 class="btn btn-light-primary w-100 fw-bolder">
                                 Lanjut ke Invoice
                             </a>
+                            
+                            <button type="button" wire:click="clearDraft" 
+                                wire:confirm="Apakah Anda yakin ingin menghapus semua pilihan (atlet & pelatih) di draf untuk event ini?"
+                                class="btn btn-light-danger w-100 fw-bolder mt-2">
+                                <i class="bi bi-trash3 me-2"></i> Kosongkan Draf
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/resources/views/livewire/coach-selection-form.blade.php
+++ b/resources/views/livewire/coach-selection-form.blade.php
@@ -39,14 +39,14 @@
 
                     @if ($this->coaches->count() > 0)
                         @php
-                            $hasConfirmedCoaches = collect($this->coaches)->contains(fn($coach) => in_array($coach->id, $getConfirmedCoachIds()));
+                            $hasConfirmedCoaches = collect($this->coaches)->contains(fn($coach) => in_array($coach->id, $this->confirmedCoachIds));
                         @endphp
 
                         <div class="border rounded p-4 bg-light">
                             @foreach ($this->coaches as $coach)
                                 @php
-                                    $isRegistered = in_array($coach->id, $registeredCoachIds);
-                                    $isConfirmed = in_array($coach->id, $getConfirmedCoachIds());
+                                    $isRegistered = in_array($coach->id, $this->registeredCoachIds);
+                                    $isConfirmed = in_array($coach->id, $this->confirmedCoachIds);
                                 @endphp
 
                                 <div class="d-flex align-items-center py-3 @if(!$loop->last) border-bottom @endif">

--- a/resources/views/livewire/event-registration-invoice.blade.php
+++ b/resources/views/livewire/event-registration-invoice.blade.php
@@ -1,0 +1,159 @@
+<div>
+    @if (session('error'))
+        @include('partials.error-alert', ['message' => session('error')])
+    @endif
+
+    @if ($errorMessage)
+        @include('partials.error-alert', ['message' => $errorMessage, 'title' => 'Terjadi Kesalahan'])
+    @endif
+
+    <div class="card shadow-sm mb-6">
+        <div class="card-body p-6">
+            <h2 class="fw-bolder text-dark mb-2">Invoice Pendaftaran Event</h2>
+            <div class="text-muted fw-bold fs-6">
+                {{ $this->event->name }}
+                <span class="mx-2 text-gray-300">|</span>
+                {{ $this->event->event_date->translatedFormat('d F Y') }}
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-6">
+        <div class="col-xl-8">
+            <div class="card shadow-sm mb-6">
+                <div class="card-header">
+                    <h3 class="card-title fw-bolder">Ringkasan Biaya</h3>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-stack mb-4">
+                        <div>
+                            <div class="fw-bolder">Biaya Event</div>
+                            <div class="text-muted fs-7">Sekali per kontingen</div>
+                        </div>
+                        <div class="fw-bolder">Rp {{ number_format($this->event->event_fee, 0, ',', '.') }}</div>
+                    </div>
+
+                    <div class="separator separator-dashed my-6"></div>
+
+                    <div class="mb-4">
+                        <div class="fw-bolder mb-2">Atlet</div>
+                        @if($this->athleteSelections->count() > 0)
+                            <div class="d-flex flex-column gap-4">
+                                @foreach($this->athleteSelections as $selection)
+                                    <div>
+                                        <div class="text-muted fs-7 mb-2">Sub-kategori: {{ $selection['subCategory']->name }}</div>
+                                        <div class="d-flex flex-column gap-2">
+                                            @foreach($selection['athletes'] as $athlete)
+                                                <div class="d-flex flex-stack">
+                                                    <span class="text-gray-700">{{ $athlete->name }}</span>
+                                                    <span class="text-gray-600">Rp {{ number_format($selection['subCategory']->price, 0, ',', '.') }}</span>
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                        <div class="d-flex flex-stack mt-3">
+                                            <span class="fw-bold text-gray-700">Subtotal Atlet</span>
+                                            <span class="fw-bolder">Rp {{ number_format($selection['subCategory']->price * $selection['athletes']->count(), 0, ',', '.') }}</span>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                            <div class="d-flex flex-stack mt-4">
+                                <span class="fw-bold text-gray-700">Total Atlet</span>
+                                <span class="fw-bolder">Rp {{ number_format($this->totalAthleteFee, 0, ',', '.') }}</span>
+                            </div>
+                        @else
+                            <div class="text-muted">Belum ada atlet dipilih.</div>
+                        @endif
+                    </div>
+
+                    <div class="separator separator-dashed my-6"></div>
+
+                    <div class="mb-2">
+                        <div class="fw-bolder mb-2">Pelatih</div>
+                        @if($this->coaches->count() > 0)
+                            <div class="d-flex flex-column gap-2">
+                                @foreach($this->coaches as $coach)
+                                    <div class="d-flex flex-stack">
+                                        <span class="text-gray-700">{{ $coach->name }}</span>
+                                        <span class="text-gray-600">Rp {{ number_format($this->event->coach_fee, 0, ',', '.') }}</span>
+                                    </div>
+                                @endforeach
+                            </div>
+                            <div class="d-flex flex-stack mt-4">
+                                <span class="fw-bold text-gray-700">Subtotal Pelatih</span>
+                                <span class="fw-bolder">Rp {{ number_format($this->totalCoachFee, 0, ',', '.') }}</span>
+                            </div>
+                        @else
+                            <div class="text-muted">Belum ada pelatih dipilih.</div>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-xl-4">
+            <div class="card shadow-sm sticky-summary">
+                <div class="card-header">
+                    <h3 class="card-title fw-bolder">Total Invoice</h3>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-stack mb-5">
+                        <span class="text-gray-600 fw-bold fs-6">Biaya Event</span>
+                        <span class="fw-bolder">Rp {{ number_format($this->event->event_fee, 0, ',', '.') }}</span>
+                    </div>
+                    <div class="d-flex flex-stack mb-5">
+                        <span class="text-gray-600 fw-bold fs-6">Subtotal Atlet</span>
+                        <span class="fw-bolder">Rp {{ number_format($this->totalAthleteFee, 0, ',', '.') }}</span>
+                    </div>
+                    <div class="d-flex flex-stack mb-5">
+                        <span class="text-gray-600 fw-bold fs-6">Subtotal Pelatih</span>
+                        <span class="fw-bolder">Rp {{ number_format($this->totalCoachFee, 0, ',', '.') }}</span>
+                    </div>
+                    <div class="separator separator-dashed my-5"></div>
+                    <div class="d-flex flex-stack">
+                        <span class="fw-bolder fs-5">Total</span>
+                        <span class="fw-bolder fs-3 text-primary">Rp {{ number_format($this->totalAmount, 0, ',', '.') }}</span>
+                    </div>
+                    <div class="d-flex flex-column gap-4 mt-6">
+                        <button wire:click="confirmSubmit" class="btn btn-primary fw-bolder">
+                            <i class="fas fa-check me-2"></i> Konfirmasi Invoice
+                        </button>
+                        <a href="{{ route('registration.index') }}" wire:navigate class="btn btn-light-danger fw-bold">
+                            Batalkan
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade {{ $showConfirmation ? 'show d-block' : '' }}" tabindex="-1" aria-hidden="{{ !$showConfirmation }}">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title fw-bolder">Konfirmasi Invoice</h3>
+                    <button type="button" class="btn btn-icon btn-sm btn-active-light-primary" wire:click="cancelConfirmation">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p class="text-muted mb-4">Pastikan data atlet dan pelatih sudah sesuai sebelum membuat invoice.</p>
+                    <div class="d-flex flex-stack">
+                        <span class="fw-bold">Total yang harus dibayar</span>
+                        <span class="fw-bolder text-primary">Rp {{ number_format($this->totalAmount, 0, ',', '.') }}</span>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-light fw-bold" wire:click="cancelConfirmation">Kembali</button>
+                    <button type="button" class="btn btn-primary fw-bolder" wire:click="submit">
+                        <i class="fas fa-check me-2"></i> Buat Invoice
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @if ($showConfirmation)
+        <div class="modal-backdrop fade show"></div>
+    @endif
+</div>

--- a/resources/views/livewire/event-registration-invoice.blade.php
+++ b/resources/views/livewire/event-registration-invoice.blade.php
@@ -39,20 +39,65 @@
                         <div class="fw-bolder mb-2">Atlet</div>
                         @if($this->athleteSelections->count() > 0)
                             <div class="d-flex flex-column gap-4">
-                                @foreach($this->athleteSelections as $selection)
+                                @foreach ($this->athleteSelections as $selection)
                                     <div>
                                         <div class="text-muted fs-7 mb-2">Sub-kategori: {{ $selection['subCategory']->name }}</div>
-                                        <div class="d-flex flex-column gap-2">
-                                            @foreach($selection['athletes'] as $athlete)
-                                                <div class="d-flex flex-stack">
-                                                    <span class="text-gray-700">{{ $athlete->name }}</span>
-                                                    <span class="text-gray-600">Rp {{ number_format($selection['subCategory']->price, 0, ',', '.') }}</span>
+                                        @if ($selection['subCategory']->isTeam())
+                                            @php
+                                                $teams = $selection['athletes']->groupBy('pivot_team_group_id');
+                                            @endphp
+                                            @foreach ($teams as $teamId => $teamAthletes)
+                                                @php
+                                                    $teamName = \App\Models\TeamGroup::find($teamId)?->team_name ?? 'Tim';
+                                                @endphp
+                                                <div class="mb-3 ps-4 border-start border-2 border-primary">
+                                                    <div class="fw-bolder fs-7 text-dark mb-1">{{ $teamName }}</div>
+                                                    <div class="d-flex flex-column gap-1">
+                                                        @foreach ($teamAthletes as $athlete)
+                                                            <div class="d-flex flex-stack fs-8">
+                                                                <span class="text-gray-600">
+                                                                    <i class="fas fa-check text-success me-2 fs-9"></i>
+                                                                    {{ $athlete->name }}
+                                                                </span>
+                                                            </div>
+                                                        @endforeach
+                                                    </div>
+                                                    <div class="d-flex flex-stack mt-2">
+                                                        <span class="text-muted fs-9 italic">Biaya Flat (Tim)</span>
+                                                        <span class="fw-bold fs-8 text-gray-800">Rp {{ number_format($selection['subCategory']->price, 0, ',', '.') }}</span>
+                                                    </div>
                                                 </div>
                                             @endforeach
-                                        </div>
-                                        <div class="d-flex flex-stack mt-3">
-                                            <span class="fw-bold text-gray-700">Subtotal Atlet</span>
-                                            <span class="fw-bolder">Rp {{ number_format($selection['subCategory']->price * $selection['athletes']->count(), 0, ',', '.') }}</span>
+                                        @else
+                                            <div class="d-flex flex-column gap-2">
+                                                @foreach ($selection['athletes'] as $athlete)
+                                                    <div class="d-flex flex-stack">
+                                                        <span class="text-gray-700">
+                                                            <i class="fas fa-user-check me-2 text-primary"></i>
+                                                            {{ $athlete->name }}
+                                                        </span>
+                                                        <span class="text-gray-600">
+                                                            Rp {{ number_format($selection['subCategory']->price, 0, ',', '.') }}
+                                                        </span>
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                        @endif
+
+                                        <div class="d-flex flex-stack mt-3 pt-3 border-top border-gray-200 border-dashed">
+                                            <span class="fw-bold text-gray-700">Subtotal {{ $selection['subCategory']->isTeam() ? 'Beregu' : 'Individu' }}</span>
+                                            <span class="fw-bolder">
+                                                @php
+                                                    if ($selection['subCategory']->isTeam()) {
+                                                        $teamCount = $selection['athletes']->pluck('pivot_team_group_id')->filter()->unique()->count();
+                                                        $teamCount = max($teamCount, 1);
+                                                        $subtotal = $selection['subCategory']->price * $teamCount;
+                                                    } else {
+                                                        $subtotal = $selection['subCategory']->price * $selection['athletes']->count();
+                                                    }
+                                                @endphp
+                                                Rp {{ number_format($subtotal, 0, ',', '.') }}
+                                            </span>
                                         </div>
                                     </div>
                                 @endforeach

--- a/resources/views/livewire/event-registration-wizard.blade.php
+++ b/resources/views/livewire/event-registration-wizard.blade.php
@@ -1,171 +1,337 @@
 <div>
     <!-- Error Message -->
     @if($errorMessage)
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
-            {{ $errorMessage }}
+        @include('partials.error-alert', ['message' => $errorMessage, 'title' => 'Terjadi Kesalahan'])
+    @endif
+
+    @if (session('success'))
+        <div class="alert alert-success d-flex align-items-center p-5 mb-6">
+            <i class="fas fa-check-circle fs-2hx text-success me-4"></i>
+            <div class="d-flex flex-column">
+                <h4 class="mb-1 text-success">Berhasil</h4>
+                <span>{{ session('success') }}</span>
+            </div>
         </div>
     @endif
 
-    <!-- Breadcrumb / Step Indicator -->
-    <nav class="flex items-center space-x-2 mb-6 text-sm">
-        <button wire:click="goToStep(1)"
-            class="{{ $currentStep >= 1 ? 'text-blue-600 font-semibold' : 'text-gray-400' }}">
-            1. Pilih Event
-        </button>
-        <span class="text-gray-400">→</span>
-        <button wire:click="goToStep(2)" {{ $currentStep < 2 ? 'disabled' : '' }}
-            class="{{ $currentStep >= 2 ? 'text-blue-600 font-semibold' : 'text-gray-400' }}">
-            2. Pilih Kategori
-        </button>
-        <span class="text-gray-400">→</span>
-        <span class="{{ $currentStep >= 3 ? 'text-blue-600 font-semibold' : 'text-gray-400' }}">
-            3. Pilih Sub-Kategori
-        </span>
-    </nav>
+    <div class="d-flex flex-column flex-xl-row">
+        <!-- Stepper Panel (Left Sidebar) -->
+        <div class="flex-column flex-lg-row-auto w-100 w-xl-350px mb-10 mb-xl-0">
+            <div class="card shadow-sm stepper-panel">
+                <div class="card-body p-8 p-lg-10">
+                    <h3 class="fw-bolder text-dark mb-8">Tahapan Pendaftaran</h3>
 
-    <!-- Loading State -->
-    <div wire:loading class="w-full text-center py-8">
-        <span class="text-gray-500 font-medium">Memuat data...</span>
-    </div>
-
-    <div wire:loading.remove>
-        <!-- Step 1: Pilih Event -->
-        @if($currentStep === 1)
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                @forelse($events ?? [] as $event)
-                    @php
-                        $isClosed = !$event->is_open;
-                        $regService = app(\App\Services\RegistrationService::class);
-                        $statusLabel = $regService->getRegistrationStatusLabel($event);
-                    @endphp
-                    <div class="bg-white border rounded-lg p-5 shadow-sm flex flex-col {{ $isClosed ? 'opacity-60 grayscale' : 'hover:shadow-md hover:border-blue-300 transition' }}">
-                        <h3 class="text-lg font-bold text-gray-800 mb-1">{{ $event->name }}</h3>
-                        <p class="text-sm text-gray-500 mb-3">
-                            <i class="fas fa-calendar-alt mr-1"></i> {{ $event->event_date->translatedFormat('d F Y') }}
-                        </p>
-                        
-                        <div class="mb-4 flex-grow">
-                            @if($isClosed)
-                                <span class="inline-block px-2 py-1 bg-red-100 text-red-700 text-xs font-semibold rounded">
-                                    {{ $statusLabel }}
-                                </span>
-                            @else
-                                <span class="inline-block px-2 py-1 bg-green-100 text-green-700 text-xs font-semibold rounded">
-                                    {{ $statusLabel }}
-                                </span>
-                            @endif
-                        </div>
-
-                        <button 
-                            wire:click="selectEvent({{ $event->id }})" 
-                            {{ $isClosed ? 'disabled' : '' }}
-                            class="w-full py-2 rounded font-semibold text-white {{ $isClosed ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700 transition' }}">
-                            {{ $isClosed ? 'Pendaftaran Ditutup' : 'Pilih Event' }}
-                        </button>
-                    </div>
-                @empty
-                    <div class="col-span-full p-8 text-center bg-gray-50 rounded-lg border border-dashed border-gray-300">
-                        <p class="text-gray-500">Belum ada event pendaftaran yang dibuka saat ini.</p>
-                    </div>
-                @endforelse
-            </div>
-        @endif
-
-        <!-- Step 2: Pilih Kategori -->
-        @if($currentStep === 2)
-            <div class="mb-6">
-                <h2 class="text-xl font-bold text-gray-800">Kategori untuk Event: {{ $selectedEventName }}</h2>
-                <p class="text-sm text-gray-500">Silakan pilih kategori yang ingin diikuti.</p>
-            </div>
-
-            @forelse($categoriesGrouped ?? [] as $type => $categories)
-                <div class="mb-8">
-                    <h3 class="text-lg font-semibold text-gray-700 mb-4 border-b pb-2">Tipe: {{ $type }}</h3>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        @foreach($categories as $category)
-                            <div class="bg-white border rounded-lg p-5 shadow-sm hover:shadow-md hover:border-blue-300 transition">
-                                <div class="flex justify-between items-start mb-2">
-                                    <h4 class="font-bold text-gray-800 text-lg">{{ $category->class_name }}</h4>
-                                    <span class="px-2 py-1 text-xs font-bold rounded {{ $type === 'Open' ? 'bg-green-100 text-green-700' : 'bg-blue-100 text-blue-700' }}">
-                                        {{ $type }}
-                                    </span>
-                                </div>
-                                <p class="text-sm text-gray-600 mb-2">
-                                    <i class="fas fa-child mr-1"></i> {{ $category->readableBirthRange() }}
-                                </p>
-                                <p class="text-sm font-medium text-gray-500 mb-4">
-                                    {{ $category->subCategories->count() }} sub-kategori tersedia
-                                </p>
-                                <button 
-                                    wire:click="selectCategory({{ $category->id }})" 
-                                    class="w-full py-2 border border-blue-600 text-blue-600 hover:bg-blue-50 hover:border-blue-700 font-semibold rounded text-sm transition">
-                                    Lihat Sub-Kategori
-                                </button>
+                    <div class="custom-stepper">
+                        <!-- Step 1 -->
+                        <div class="custom-stepper-item {{ $currentStep === 1 ? 'active' : ($currentStep > 1 ? 'completed' : '') }}" wire:click="goToStep(1)" style="cursor: pointer;">
+                            <div class="custom-stepper-circle">
+                                @if($currentStep > 1)
+                                    <i class="fas fa-check"></i>
+                                @else
+                                    <span>1</span>
+                                @endif
                             </div>
-                        @endforeach
+                            <div class="custom-stepper-content">
+                                <h4 class="custom-stepper-title">Event</h4>
+                                <p class="custom-stepper-desc">Pilih Event</p>
+                            </div>
+                        </div>
+
+                        <!-- Step 2 -->
+                        <div class="custom-stepper-item {{ $currentStep === 2 ? 'active' : ($currentStep > 2 ? 'completed' : '') }}" @if($currentStep >= 2) wire:click="goToStep(2)" style="cursor: pointer;" @endif>
+                            <div class="custom-stepper-circle">
+                                @if($currentStep > 2)
+                                    <i class="fas fa-check"></i>
+                                @else
+                                    <span>2</span>
+                                @endif
+                            </div>
+                            <div class="custom-stepper-content">
+                                <h4 class="custom-stepper-title">Kategori</h4>
+                                <p class="custom-stepper-desc">Pilih Kategori</p>
+                            </div>
+                        </div>
+
+                        <!-- Step 3 -->
+                        <div class="custom-stepper-item {{ $currentStep === 3 ? 'active' : '' }}">
+                            <div class="custom-stepper-circle">
+                                <span>3</span>
+                            </div>
+                            <div class="custom-stepper-content">
+                                <h4 class="custom-stepper-title">Sub-Kategori</h4>
+                                <p class="custom-stepper-desc">Pilih Kelas</p>
+                            </div>
+                        </div>
                     </div>
                 </div>
-            @empty
-                <div class="p-8 text-center bg-gray-50 rounded-lg border border-dashed border-gray-300">
-                    <p class="text-gray-500">Tidak ada kategori untuk event ini.</p>
-                </div>
-            @endforelse
-        @endif
+            </div>
+        </div>
 
-        <!-- Step 3: Pilih Sub Kategori -->
-        @if($currentStep === 3)
-            <div class="mb-6">
-                <h2 class="text-xl font-bold text-gray-800">Sub-Kategori: {{ $selectedCategoryName }}</h2>
-                <p class="text-sm text-gray-500">Pilih sub-kategori pertandingan untuk lanjut ke pengisian data peserta.</p>
+        <!-- Content Panel (Right Side) -->
+        <div class="flex-lg-row-fluid ms-xl-10">
+            <!-- Loading State -->
+            <div wire:loading class="w-100 text-center py-10">
+                <div class="spinner-border text-primary" role="status">
+                    <span class="visually-hidden">Memuat data...</span>
+                </div>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-                @forelse($subCategories ?? [] as $subCategory)
-                    <div class="bg-white border rounded-lg p-5 shadow-sm flex flex-col hover:border-blue-400 hover:shadow-md transition cursor-pointer" wire:click="selectSubCategory({{ $subCategory->id }})">
-                        <div class="flex justify-between items-start mb-3">
-                            <h4 class="font-bold text-gray-800 text-lg">{{ $subCategory->name }}</h4>
+            <div wire:loading.remove>
+                <!-- Step 1: Pilih Event -->
+                @if($currentStep === 1)
+                    <div class="mb-7">
+                        <h2 class="fw-bolder text-dark">Pilih Event Pendaftaran</h2>
+                        <div class="text-muted fw-bold fs-6 mt-2">Silakan pilih event yang sedang membuka pendaftaran.</div>
+                    </div>
+                    <div class="row g-6">
+                        @forelse($events ?? [] as $event)
                             @php
-                                $genderClass = match($subCategory->gender->value) {
-                                    'M' => 'bg-blue-100 text-blue-700',
-                                    'F' => 'bg-pink-100 text-pink-700',
-                                    default => 'bg-purple-100 text-purple-700',
-                                };
-                                $genderLabel = match($subCategory->gender->value) {
-                                    'M' => 'Putra',
-                                    'F' => 'Putri',
-                                    default => 'Campuran',
-                                };
+                                $isClosed = !$event->is_open;
+                                $statusLabel = $statusLabels[$event->id] ?? '';
                             @endphp
-                            <span class="px-2 py-1 text-xs font-bold rounded {{ $genderClass }}">
-                                {{ $genderLabel }}
-                            </span>
+                            <div class="col-md-6">
+                                <div class="card card-flush shadow-sm h-100 {{ $isClosed ? 'opacity-50' : 'hover-elevate-up' }}">
+                                    <div class="card-body p-6 d-flex flex-column h-100">
+                                        <div class="mb-5">
+                                            <div class="d-flex flex-stack mb-3">
+                                                @if($isClosed)
+                                                    <span class="badge badge-light-danger fw-bolder">{{ $statusLabel }}</span>
+                                                @else
+                                                    <span class="badge badge-light-success fw-bolder">{{ $statusLabel }}</span>
+                                                @endif
+                                            </div>
+                                            <span class="text-dark fw-bolder fs-4">{{ $event->name }}</span>
+                                            <div class="text-muted fw-bold mt-2">
+                                                <i class="fas fa-calendar-alt me-2 text-muted"></i> {{ $event->event_date->translatedFormat('d F Y') }}
+                                            </div>
+                                        </div>
+                                        <div class="mt-auto">
+                                            <button
+                                                wire:click="selectEvent({{ $event->id }})"
+                                                {{ $isClosed ? 'disabled' : '' }}
+                                                class="btn w-100 {{ $isClosed ? 'btn-light' : 'btn-primary' }}">
+                                                {{ $isClosed ? 'Pendaftaran Ditutup' : 'Pilih Event' }}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @empty
+                            <div class="col-12">
+                                <div class="notice d-flex bg-light-warning rounded border-warning border border-dashed p-6">
+                                    <i class="fas fa-info-circle fs-2tx text-warning me-4"></i>
+                                    <div class="d-flex flex-stack flex-grow-1">
+                                        <div class="fw-semibold">
+                                            <h4 class="text-gray-900 fw-bold">Perhatian</h4>
+                                            <div class="fs-6 text-gray-700">Belum ada event pendaftaran yang dibuka saat ini.</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @endforelse
+                    </div>
+                @endif
+
+                <!-- Step 2: Pilih Kategori -->
+                @if($currentStep === 2)
+                    <div class="mb-7">
+                        <h2 class="fw-bolder text-dark">Kategori Event: <span class="text-primary">{{ $selectedEventName }}</span></h2>
+                        <div class="text-muted fw-bold fs-6 mt-2">Silakan pilih kategori yang ingin diikuti.</div>
+                    </div>
+
+                    @forelse($categoriesGrouped ?? [] as $type => $categories)
+                        <div class="mb-10">
+                            <h3 class="text-gray-700 fw-bolder fs-4 mb-7 border-bottom border-2 border-gray-200 pb-4">Tipe: {{ $type }}</h3>
+                            <div class="row g-6">
+                                @foreach($categories as $category)
+                                    <div class="col-md-6">
+                                        <div class="card shadow-sm border border-dashed hover-elevate-up h-100">
+                                            <div class="card-body p-6">
+                                                <div class="d-flex justify-content-between align-items-start mb-4">
+                                                    <h4 class="fw-bolder text-dark fs-5">{{ $category->class_name }}</h4>
+                                                    <span class="badge {{ $type === 'Open' ? 'badge-light-success' : 'badge-light-primary' }} fw-bolder">
+                                                        {{ $type }}
+                                                    </span>
+                                                </div>
+                                                <div class="d-flex align-items-center mb-4 text-muted fw-bold fs-6">
+                                                    <i class="fas fa-child me-2 text-primary"></i> {{ $category->readableBirthRange() }}
+                                                </div>
+                                                <div class="d-flex align-items-center mb-6 text-muted fw-bold fs-6">
+                                                    <i class="fas fa-layer-group me-2 text-info"></i> {{ $category->subCategories->count() }} sub-kategori tersedia
+                                                </div>
+                                                <button 
+                                                    wire:click="selectCategory({{ $category->id }})" 
+                                                    class="btn btn-outline btn-outline-dashed btn-outline-primary btn-active-light-primary w-100 fw-bolder">
+                                                    Lihat Sub-Kategori
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
                         </div>
-                        
-                        <div class="mb-5 flex-grow">
-                            <p class="text-xl font-bold text-gray-900 mb-3">
-                                Rp {{ number_format($subCategory->price, 0, ',', '.') }}
-                            </p>
-                            @if($subCategory->isTeam())
-                                <span class="inline-flex items-center px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded">
-                                    <i class="fas fa-users mr-1"></i> Beregu (min {{ $subCategory->min_participants }}, max {{ $subCategory->max_participants }})
+                    @empty
+                        <div class="notice d-flex bg-light-info rounded border-info border border-dashed p-6">
+                            <i class="fas fa-folder-open fs-2tx text-info me-4"></i>
+                            <div class="fw-semibold">
+                                <h4 class="text-gray-900 fw-bold">Kosong</h4>
+                                <div class="fs-6 text-gray-700">Tidak ada kategori untuk event ini.</div>
+                            </div>
+                        </div>
+                    @endforelse
+                @endif
+
+                <!-- Step 3: Pilih Sub Kategori -->
+                @if($currentStep === 3)
+                    <div class="mb-7">
+                        <h2 class="fw-bolder text-dark">Sub-Kategori: <span class="text-primary">{{ $selectedCategoryName }}</span></h2>
+                        <div class="text-muted fw-bold fs-6 mt-2">Pilih sub-kategori pertandingan untuk lanjut ke pengisian data peserta.</div>
+                    </div>
+
+                    <div class="card shadow-sm mb-7">
+                        <div class="card-body d-flex flex-wrap flex-column flex-md-row justify-content-between align-items-start gap-4">
+                            <div>
+                                <h3 class="fw-bolder text-dark mb-2">
+                                    <i class="fas fa-user-tie text-primary me-2"></i>
+                                    Pendaftaran Pelatih
+                                </h3>
+                                <div class="text-muted fw-bold fs-7">
+                                    Pelatih didaftarkan untuk event (opsional), tidak per kelas.
+                                </div>
+                            </div>
+                            <div class="d-flex flex-wrap gap-3">
+                                <span class="badge badge-light-primary fw-bolder align-self-center">
+                                    {{ $selectedCoachCount }} pelatih terpilih
                                 </span>
+                                <a href="{{ $selectedEventId ? route('registration.invoice', ['event' => $selectedEventId]) : '#' }}"
+                                    class="btn btn-primary fw-bolder {{ $selectedEventId ? '' : 'disabled' }}">
+                                    Lanjut ke Invoice
+                                </a>
+                            </div>
+                        </div>
+                        <div class="card-body pt-0">
+                            @if(($coaches ?? collect())->count() === 0)
+                                <div class="text-center py-6 bg-light rounded border border-dashed">
+                                    <i class="fas fa-user-slash fs-2x text-muted mb-2"></i>
+                                    <div class="text-muted fw-bold">Belum ada pelatih di bank peserta.</div>
+                                </div>
                             @else
-                                <span class="inline-flex items-center px-2 py-1 bg-gray-100 text-gray-800 text-xs font-medium rounded">
-                                    <i class="fas fa-user mr-1"></i> Individu
-                                </span>
+                                <div class="row g-4">
+                                    @foreach(($coaches ?? collect()) as $coach)
+                                        @php
+                                            $isRegistered = in_array($coach->id, $registeredCoachIds ?? [], true);
+                                            $isSelected = in_array($coach->id, $draftCoachIds ?? [], true);
+                                        @endphp
+                                        <div class="col-md-6">
+                                            <label wire:key="coach-{{ $coach->id }}"
+                                                class="d-flex flex-stack p-4 rounded border border-dashed {{ $isRegistered ? 'bg-light-danger' : 'bg-hover-light' }}">
+                                                <div class="d-flex align-items-center">
+                                                    <div class="symbol symbol-40px me-4">
+                                                        <img src="{{ $coach->photo_url }}" alt="{{ $coach->name }}" class="coach-photo">
+                                                    </div>
+                                                    <div class="d-flex flex-column">
+                                                        <span class="fw-bolder text-gray-800">{{ $coach->name }}</span>
+                                                        @if($isRegistered)
+                                                            <span class="text-danger fw-bold fs-7">Sudah terdaftar di event ini</span>
+                                                        @else
+                                                            <span class="text-muted fw-bold fs-7">Pelatih</span>
+                                                        @endif
+                                                    </div>
+                                                </div>
+                                                <div class="form-check form-check-solid form-check-custom form-check-primary">
+                                                    <input class="form-check-input" type="checkbox" value="{{ $coach->id }}"
+                                                        wire:model.live="selectedCoachIds" id="coach_{{ $coach->id }}"
+                                                        {{ $isRegistered ? 'disabled' : '' }}>
+                                                </div>
+                                            </label>
+                                        </div>
+                                    @endforeach
+                                </div>
                             @endif
                         </div>
+                    </div>
 
-                        <button class="w-full py-2 bg-blue-50 border border-transparent text-blue-700 hover:bg-blue-600 hover:text-white font-semibold rounded transition text-sm">
-                            Daftar Kelas Ini
-                        </button>
+                    @if(($draftSelections ?? collect())->count() > 0)
+                        <div class="card shadow-sm mb-7">
+                            <div class="card-header">
+                                <h3 class="card-title fw-bolder">
+                                    <i class="fas fa-list-check text-success me-2"></i>
+                                    Ringkasan Draft Atlet
+                                </h3>
+                            </div>
+                            <div class="card-body">
+                                <div class="d-flex flex-column gap-4">
+                                    @foreach($draftSelections as $draft)
+                                        <div class="d-flex flex-stack">
+                                            <div>
+                                                <div class="fw-bolder">{{ $draft['subCategory']->name }}</div>
+                                                <div class="text-muted fs-7">{{ $draft['subCategory']->eventCategory->class_name }}</div>
+                                            </div>
+                                            <span class="badge badge-light-success fw-bolder">{{ $draft['athlete_count'] }} atlet</span>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+
+                    <div class="row g-6">
+                        @forelse($subCategories ?? [] as $subCategory)
+                            <div class="col-md-6 col-lg-4">
+                                <div class="card shadow-sm border border-hover-primary h-100 cursor-pointer" wire:click="selectSubCategory({{ $subCategory->id }})">
+                                    <div class="card-body p-6 d-flex flex-column">
+                                        <div class="d-flex justify-content-between align-items-start mb-4">
+                                            <h4 class="fw-bolder text-dark fs-5">{{ $subCategory->name }}</h4>
+                                            @php
+                                                $genderClass = match($subCategory->gender->value) {
+                                                    'M' => 'badge-light-primary',
+                                                    'F' => 'badge-light-danger',
+                                                    default => 'badge-light-info',
+                                                };
+                                                $genderLabel = match($subCategory->gender->value) {
+                                                    'M' => 'Putra',
+                                                    'F' => 'Putri',
+                                                    default => 'Campuran',
+                                                };
+                                            @endphp
+                                            <span class="badge {{ $genderClass }} fw-bolder">{{ $genderLabel }}</span>
+                                        </div>
+                                        
+                                        <div class="flex-grow-1 mb-5">
+                                            <div class="fs-2 fw-bolder text-gray-900 mb-3">
+                                                Rp {{ number_format($subCategory->price, 0, ',', '.') }}
+                                            </div>
+                                            @if($subCategory->isTeam())
+                                                <div class="d-flex align-items-center text-warning fw-bold fs-7">
+                                                    <i class="fas fa-users me-2 text-warning"></i> Beregu ({{ $subCategory->min_participants }} - {{ $subCategory->max_participants }} org)
+                                                </div>
+                                            @else
+                                                <div class="d-flex align-items-center text-gray-600 fw-bold fs-7">
+                                                    <i class="fas fa-user me-2 text-gray-600"></i> Individu
+                                                </div>
+                                            @endif
+                                        </div>
+
+                                        <button class="btn btn-light-primary w-100 fw-bolder text-hover-white">
+                                            Daftar Kelas Ini
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        @empty
+                            <div class="col-12">
+                                <div class="notice d-flex bg-light-secondary rounded border-gray-300 border border-dashed p-6">
+                                    <i class="fas fa-layer-group fs-2tx text-gray-500 me-4"></i>
+                                    <div class="fw-semibold">
+                                        <h4 class="text-gray-900 fw-bold">Kosong</h4>
+                                        <div class="fs-6 text-gray-700">Tidak ada sub-kategori yang tersedia.</div>
+                                    </div>
+                                </div>
+                            </div>
+                        @endforelse
                     </div>
-                @empty
-                    <div class="col-span-full p-8 text-center bg-gray-50 rounded-lg border border-dashed border-gray-300">
-                        <p class="text-gray-500">Tidak ada sub-kategori yang tersedia.</p>
-                    </div>
-                @endforelse
+                @endif
             </div>
-        @endif
+        </div>
     </div>
 </div>

--- a/resources/views/livewire/event-registration-wizard.blade.php
+++ b/resources/views/livewire/event-registration-wizard.blade.php
@@ -188,69 +188,6 @@
                         <div class="text-muted fw-bold fs-6 mt-2">Pilih sub-kategori pertandingan untuk lanjut ke pengisian data peserta.</div>
                     </div>
 
-                    <div class="card shadow-sm mb-7">
-                        <div class="card-body d-flex flex-wrap flex-column flex-md-row justify-content-between align-items-start gap-4">
-                            <div>
-                                <h3 class="fw-bolder text-dark mb-2">
-                                    <i class="fas fa-user-tie text-primary me-2"></i>
-                                    Pendaftaran Pelatih
-                                </h3>
-                                <div class="text-muted fw-bold fs-7">
-                                    Pelatih didaftarkan untuk event (opsional), tidak per kelas.
-                                </div>
-                            </div>
-                            <div class="d-flex flex-wrap gap-3">
-                                <span class="badge badge-light-primary fw-bolder align-self-center">
-                                    {{ $selectedCoachCount }} pelatih terpilih
-                                </span>
-                                <a href="{{ $selectedEventId ? route('registration.invoice', ['event' => $selectedEventId]) : '#' }}"
-                                    class="btn btn-primary fw-bolder {{ $selectedEventId ? '' : 'disabled' }}">
-                                    Lanjut ke Invoice
-                                </a>
-                            </div>
-                        </div>
-                        <div class="card-body pt-0">
-                            @if(($coaches ?? collect())->count() === 0)
-                                <div class="text-center py-6 bg-light rounded border border-dashed">
-                                    <i class="fas fa-user-slash fs-2x text-muted mb-2"></i>
-                                    <div class="text-muted fw-bold">Belum ada pelatih di bank peserta.</div>
-                                </div>
-                            @else
-                                <div class="row g-4">
-                                    @foreach(($coaches ?? collect()) as $coach)
-                                        @php
-                                            $isRegistered = in_array($coach->id, $registeredCoachIds ?? [], true);
-                                            $isSelected = in_array($coach->id, $draftCoachIds ?? [], true);
-                                        @endphp
-                                        <div class="col-md-6">
-                                            <label wire:key="coach-{{ $coach->id }}"
-                                                class="d-flex flex-stack p-4 rounded border border-dashed {{ $isRegistered ? 'bg-light-danger' : 'bg-hover-light' }}">
-                                                <div class="d-flex align-items-center">
-                                                    <div class="symbol symbol-40px me-4">
-                                                        <img src="{{ $coach->photo_url }}" alt="{{ $coach->name }}" class="coach-photo">
-                                                    </div>
-                                                    <div class="d-flex flex-column">
-                                                        <span class="fw-bolder text-gray-800">{{ $coach->name }}</span>
-                                                        @if($isRegistered)
-                                                            <span class="text-danger fw-bold fs-7">Sudah terdaftar di event ini</span>
-                                                        @else
-                                                            <span class="text-muted fw-bold fs-7">Pelatih</span>
-                                                        @endif
-                                                    </div>
-                                                </div>
-                                                <div class="form-check form-check-solid form-check-custom form-check-primary">
-                                                    <input class="form-check-input" type="checkbox" value="{{ $coach->id }}"
-                                                        wire:model.live="selectedCoachIds" id="coach_{{ $coach->id }}"
-                                                        {{ $isRegistered ? 'disabled' : '' }}>
-                                                </div>
-                                            </label>
-                                        </div>
-                                    @endforeach
-                                </div>
-                            @endif
-                        </div>
-                    </div>
-
                     @if(($draftSelections ?? collect())->count() > 0)
                         <div class="card shadow-sm mb-7">
                             <div class="card-header">

--- a/resources/views/livewire/event-registration-wizard.blade.php
+++ b/resources/views/livewire/event-registration-wizard.blade.php
@@ -204,7 +204,13 @@
                                                 <div class="fw-bolder">{{ $draft['subCategory']->name }}</div>
                                                 <div class="text-muted fs-7">{{ $draft['subCategory']->eventCategory->class_name }}</div>
                                             </div>
-                                            <span class="badge badge-light-success fw-bolder">{{ $draft['athlete_count'] }} atlet</span>
+                                            <span class="badge badge-light-success fw-bolder">
+                                                @if (isset($draft['team_count']))
+                                                    {{ $draft['team_count'] }} Tim ({{ $draft['athlete_count'] }} Atlet)
+                                                @else
+                                                    {{ $draft['athlete_count'] }} Atlet
+                                                @endif
+                                            </span>
                                         </div>
                                     @endforeach
                                 </div>
@@ -248,6 +254,21 @@
                                                 </div>
                                             @endif
                                         </div>
+
+                                        {{-- Preview Atlet di draf --}}
+                                        @php
+                                            $currentDraft = collect($draftSelections)->firstWhere('subCategory.id', $subCategory->id);
+                                        @endphp
+                                        @if($currentDraft)
+                                            <div class="mb-4 bg-light-success p-3 rounded border border-success border-dashed">
+                                                <div class="fw-bold text-success fs-8 mb-1">DRAF TERPILIH:</div>
+                                                <div class="d-flex flex-wrap gap-1">
+                                                    @foreach($currentDraft['athlete_names'] as $name)
+                                                        <span class="badge badge-success fs-9 px-2 py-1">{{ $name }}</span>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        @endif
 
                                         <button class="btn btn-light-primary w-100 fw-bolder text-hover-white">
                                             Daftar Kelas Ini

--- a/resources/views/participants/edit.blade.php
+++ b/resources/views/participants/edit.blade.php
@@ -1,15 +1,14 @@
 <x-app-layout>
     @section('title', 'Edit Peserta - ' . $participant->name)
 
-    @php$__puser = auth()->user();
-                $canEditView =
-                    $__puser &&
-                    ($__puser->can('edit participants') ||
-                        $__puser->can('manage participants') ||
-                        ($__puser->can('manage own participants') &&
-                            $participant->contingent_id === $__puser->contingent?->id))
-        ;
-    @endphp ?>
+    @php
+        $__puser = auth()->user();
+        $canEditView = $__puser && (
+            $__puser->can('edit participants') || 
+            $__puser->can('manage participants') || 
+            ($__puser->can('manage own participants') && $participant->contingent_id === $__puser->contingent?->id)
+        );
+    @endphp
 
     @if (!$canEditView)
         <div class="card">
@@ -119,7 +118,7 @@
                                 @if ($participant->photo)
                                     <div class="mb-3">
                                         <div class="symbol symbol-circle symbol-100px overflow-hidden">
-                                            <img src="{{ Storage::url($participant->photo) }}"
+                                            <img src="{{ $participant->photo_url }}"
                                                 alt="{{ $participant->name }}" class="w-100 h-100 object-fit-cover" />
                                         </div>
                                     </div>

--- a/resources/views/participants/index.blade.php
+++ b/resources/views/participants/index.blade.php
@@ -74,7 +74,7 @@
                                     <div class="symbol symbol-circle symbol-50px overflow-hidden me-3"
                                         style="width:50px;height:50px">
                                         @if ($participant->photo)
-                                            <img src="{{ Storage::url($participant->photo) }}"
+                                            <img src="{{ $participant->photo_url }}"
                                                 alt="{{ $participant->name }}"
                                                 style="width:50px;height:50px;object-fit:cover" />
                                         @else
@@ -350,7 +350,7 @@
                             <div
                                 class="p-card-av {{ $participant->type === \App\Enums\ParticipantType::Coach ? 'bg-light-success text-success' : ($participant->type === \App\Enums\ParticipantType::Official ? 'bg-light-info text-info' : 'bg-light-warning text-warning') }}">
                                 @if ($participant->photo)
-                                    <img src="{{ Storage::url($participant->photo) }}"
+                                    <img src="{{ $participant->photo_url }}"
                                         alt="{{ $participant->name }}" />
                                 @else
                                     {{ strtoupper(substr($participant->name, 0, 1)) }}

--- a/resources/views/participants/show.blade.php
+++ b/resources/views/participants/show.blade.php
@@ -46,7 +46,7 @@
                 <div class="me-7 mb-4">
                     <div class="symbol symbol-100px symbol-lg-160px symbol-fixed position-relative">
                         @if ($participant->photo)
-                            <img src="{{ Storage::url($participant->photo) }}" alt="{{ $participant->name }}"
+                            <img src="{{ $participant->photo_url }}" alt="{{ $participant->name }}"
                                 class="w-100 h-100 object-fit-cover" />
                         @else
                             <div
@@ -197,7 +197,6 @@
                                     <td class="text-gray-600 fw-bold">Institusi</td>
                                     <td class="text-gray-800">{{ $participant->institusi ?? '-' }}</td>
                                 </tr>
-                                @endif
                             </tbody>
                         </table>
                     </div>
@@ -270,15 +269,17 @@
     </div>
 
     @push('scripts')
-        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
-        new bootstrap.Tooltip(el);
-        });
+        <script>
+            document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function(el) {
+                new bootstrap.Tooltip(el);
+            });
 
-        @if (session('success'))
-            toastr.success("{{ session('success') }}");
-        @endif
-        @if ($errors->has('delete'))
-            toastr.error("{{ $errors->first('delete') }}");
-        @endif
+            @if (session('success'))
+                toastr.success("{{ session('success') }}");
+            @endif
+            @if ($errors->has('delete'))
+                toastr.error("{{ $errors->first('delete') }}");
+            @endif
+        </script>
     @endpush
 </x-app-layout>

--- a/resources/views/registration/index.blade.php
+++ b/resources/views/registration/index.blade.php
@@ -1,9 +1,7 @@
 <x-app-layout>
-    @section('title', 'Pendaftaran Event')
+    @section('title', 'Pendaftaran Atlet')
 
-    <div class="py-6">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <livewire:event-registration-wizard />
-        </div>
+    <div class="py-10">
+        <livewire:event-registration-wizard />
     </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,6 +92,9 @@ Route::middleware('auth')->group(function () {
         Route::get('registration/create/{event}/{category}/{sub_category}', \App\Livewire\AthleteSelectionForm::class)
             ->name('registration.create');
 
+        Route::get('registration/coaches', \App\Livewire\CoachSelectionForm::class)
+            ->name('registration.coaches');
+
         Route::get('registration/invoice/{event}', \App\Livewire\EventRegistrationInvoice::class)
             ->name('registration.invoice');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,10 +87,13 @@ Route::middleware('auth')->group(function () {
         Route::get('registration', function () {
             return view('registration.index');
         })->name('registration.index');
-        
+
         // Placeholder for the next module
         Route::get('registration/create/{event}/{category}/{sub_category}', \App\Livewire\AthleteSelectionForm::class)
             ->name('registration.create');
+
+        Route::get('registration/invoice/{event}', \App\Livewire\EventRegistrationInvoice::class)
+            ->name('registration.invoice');
     });
 });
 

--- a/tests/Feature/Livewire/CoachSelectionFormTest.php
+++ b/tests/Feature/Livewire/CoachSelectionFormTest.php
@@ -8,44 +8,37 @@ use App\Models\Registration;
 use App\Models\User;
 use App\Enums\ParticipantType;
 use App\Enums\PaymentStatus;
-use App\Enums\EventStatus;
+use App\Enums\RegistrationStatus;
+use Spatie\Permission\Models\Permission;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 beforeEach(function () {
-    $this->user = User::factory()->create(['username' => 'user_' . Str::random(5)]);
-    $this->contingent = Contingent::create([
-        'user_id' => $this->user->id,
-        'name' => 'Dojo Testing',
-        'official_name' => 'Manager Dojo',
-        'phone' => '08123456789',
-        'address' => 'Test Address',
-    ]);
+    // Create permission
+    Permission::firstOrCreate(['name' => 'create registrations', 'guard_name' => 'web']);
+
+    $this->contingent = Contingent::factory()->create();
+    $this->user = $this->contingent->user;
+    $this->user->givePermissionTo('create registrations');
 
     // Create coaches
     $this->coach1 = Participant::factory()->create([
         'type' => ParticipantType::Coach,
         'contingent_id' => $this->contingent->id,
         'name' => 'Coach One',
-        'photo' => 'coach1.jpg',
     ]);
 
     $this->coach2 = Participant::factory()->create([
         'type' => ParticipantType::Coach,
         'contingent_id' => $this->contingent->id,
         'name' => 'Coach Two',
-        'photo' => 'coach2.jpg',
     ]);
 
     // Create open event
-    $this->event = Event::create([
-        'name' => 'Test Event Open',
-        'event_date' => now()->addDays(20),
-        'registration_deadline' => now()->addDays(10),
-        'status' => EventStatus::RegistrationOpen,
+    $this->event = Event::factory()->create([
+        'registration_deadline' => Carbon::now()->addDays(7),
+        'status' => \App\Enums\EventStatus::RegistrationOpen,
         'coach_fee' => 50000,
-        'event_fee' => 100000,
     ]);
 });
 
@@ -54,99 +47,88 @@ test('user can see coach selection form', function () {
 
     Livewire::test(CoachSelectionForm::class)
         ->assertStatus(200)
-        ->assertSee('Pendaftaran Pelatih')
-        ->assertSee('Pilih Event');
+        ->assertSee('Pendaftaran Pelatih');
 });
 
-test('user can select event', function () {
+test('user can select event and see coaches', function () {
     $this->actingAs($this->user);
 
     Livewire::test(CoachSelectionForm::class)
         ->set('selectedEventId', $this->event->id)
-        ->assertSet('selectedEventId', $this->event->id);
+        ->assertSee('Coach One')
+        ->assertSee('Coach Two');
 });
 
-test('user can select coaches and they are saved to registration', function () {
+test('user can register coaches', function () {
     $this->actingAs($this->user);
 
     Livewire::test(CoachSelectionForm::class)
         ->set('selectedEventId', $this->event->id)
         ->set('selectedCoachIds', [$this->coach1->id])
-        ->assertHasNoErrors();
+        ->assertSet('showSavedIndicator', true);
 
-    $this->assertDatabaseHas('registrations', [
+    $this->assertDatabaseHas('registration_draft_items', [
         'participant_id' => $this->coach1->id,
         'sub_category_id' => null,
     ]);
+
+    $this->assertDatabaseHas('registration_drafts', [
+        'contingent_id' => $this->contingent->id,
+        'event_id' => $this->event->id,
+    ]);
 });
 
-test('unchecking coach removes registration', function () {
+test('user can unregister coaches', function () {
     $this->actingAs($this->user);
+    
+    // Setup initial draft
+    $draft = \App\Models\RegistrationDraft::create([
+        'contingent_id' => $this->contingent->id,
+        'event_id' => $this->event->id,
+        'status' => 'draft',
+    ]);
+    
+    \App\Models\RegistrationDraftItem::create([
+        'registration_draft_id' => $draft->id,
+        'participant_id' => $this->coach1->id,
+        'sub_category_id' => null,
+    ]);
 
-    // First select a coach to create registration, then uncheck it
     Livewire::test(CoachSelectionForm::class)
         ->set('selectedEventId', $this->event->id)
-        ->set('selectedCoachIds', [$this->coach1->id])
-        ->assertHasNoErrors()
         ->set('selectedCoachIds', [])
-        ->assertHasNoErrors();
+        ->assertSet('showSavedIndicator', true);
 
-    // Verify registration was soft-deleted
+    $this->assertDatabaseMissing('registration_draft_items', [
+        'participant_id' => $this->coach1->id,
+    ]);
+});
+
+test('cannot modify coaches if payment is confirmed', function () {
+    $this->actingAs($this->user);
+    
+    // Setup confirmed registration
+    $payment = \App\Models\Payment::create([
+        'contingent_id' => $this->contingent->id,
+        'event_id' => $this->event->id,
+        'status' => PaymentStatus::Verified,
+        'total_amount' => 50000,
+    ]);
+    
+    Registration::create([
+        'participant_id' => $this->coach1->id,
+        'payment_id' => $payment->id,
+        'sub_category_id' => null,
+        'status_berkas' => RegistrationStatus::Verified,
+    ]);
+
+    Livewire::test(CoachSelectionForm::class)
+        ->set('selectedEventId', $this->event->id)
+        ->set('selectedCoachIds', [])
+        ->assertSee('Pelatih yang sudah masuk invoice confirmed tidak dapat diubah');
+
+    // Registration should still exist
     $this->assertDatabaseHas('registrations', [
         'participant_id' => $this->coach1->id,
     ]);
-    $this->assertSoftDeleted('registrations', [
-        'participant_id' => $this->coach1->id,
-    ]);
-});
-
-test('only shows open events', function () {
-    $this->actingAs($this->user);
-
-    $closedEvent = Event::create([
-        'name' => 'Test Event Closed',
-        'event_date' => now()->addDays(20),
-        'registration_deadline' => now()->subDays(1),
-        'status' => EventStatus::RegistrationClosed,
-        'coach_fee' => 50000,
-        'event_fee' => 100000,
-    ]);
-
-    Livewire::test(CoachSelectionForm::class)
-        ->set('selectedEventId', $closedEvent->id)
-        ->assertSet('selectedEventId', null)
-        ->assertSee('Event tidak valid atau pendaftaran sudah ditutup');
-});
-
-test('validates user has contingent', function () {
-    $userWithoutContingent = User::factory()->create(['username' => 'user_' . Str::random(5)]);
-
-    $this->actingAs($userWithoutContingent);
-
-    Livewire::test(CoachSelectionForm::class)
-        ->assertStatus(403);
-});
-
-test('shows only coaches from users contingent', function () {
-    $otherUser = User::factory()->create(['username' => 'user_' . Str::random(5)]);
-    $otherContingent = Contingent::create([
-        'user_id' => $otherUser->id,
-        'name' => 'Other Dojo',
-        'official_name' => 'Other Manager',
-        'phone' => '08987654321',
-        'address' => 'Other Address',
-    ]);
-    $otherCoach = Participant::factory()->create([
-        'type' => ParticipantType::Coach,
-        'contingent_id' => $otherContingent->id,
-        'photo' => 'other-coach.jpg',
-    ]);
-
-    $this->actingAs($this->user);
-
-    Livewire::test(CoachSelectionForm::class)
-        ->set('selectedEventId', $this->event->id)
-        ->assertSee($this->coach1->name)
-        ->assertSee($this->coach2->name)
-        ->assertDontSee($otherCoach->name);
 });

--- a/tests/Feature/Livewire/CoachSelectionFormTest.php
+++ b/tests/Feature/Livewire/CoachSelectionFormTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use App\Livewire\CoachSelectionForm;
+use App\Models\Contingent;
+use App\Models\Event;
+use App\Models\Participant;
+use App\Models\Registration;
+use App\Models\User;
+use App\Enums\ParticipantType;
+use App\Enums\PaymentStatus;
+use App\Enums\EventStatus;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create(['username' => 'user_' . Str::random(5)]);
+    $this->contingent = Contingent::create([
+        'user_id' => $this->user->id,
+        'name' => 'Dojo Testing',
+        'official_name' => 'Manager Dojo',
+        'phone' => '08123456789',
+        'address' => 'Test Address',
+    ]);
+
+    // Create coaches
+    $this->coach1 = Participant::factory()->create([
+        'type' => ParticipantType::Coach,
+        'contingent_id' => $this->contingent->id,
+        'name' => 'Coach One',
+        'photo' => 'coach1.jpg',
+    ]);
+
+    $this->coach2 = Participant::factory()->create([
+        'type' => ParticipantType::Coach,
+        'contingent_id' => $this->contingent->id,
+        'name' => 'Coach Two',
+        'photo' => 'coach2.jpg',
+    ]);
+
+    // Create open event
+    $this->event = Event::create([
+        'name' => 'Test Event Open',
+        'event_date' => now()->addDays(20),
+        'registration_deadline' => now()->addDays(10),
+        'status' => EventStatus::RegistrationOpen,
+        'coach_fee' => 50000,
+        'event_fee' => 100000,
+    ]);
+});
+
+test('user can see coach selection form', function () {
+    $this->actingAs($this->user);
+
+    Livewire::test(CoachSelectionForm::class)
+        ->assertStatus(200)
+        ->assertSee('Pendaftaran Pelatih')
+        ->assertSee('Pilih Event');
+});
+
+test('user can select event', function () {
+    $this->actingAs($this->user);
+
+    Livewire::test(CoachSelectionForm::class)
+        ->set('selectedEventId', $this->event->id)
+        ->assertSet('selectedEventId', $this->event->id);
+});
+
+test('user can select coaches and they are saved to registration', function () {
+    $this->actingAs($this->user);
+
+    Livewire::test(CoachSelectionForm::class)
+        ->set('selectedEventId', $this->event->id)
+        ->set('selectedCoachIds', [$this->coach1->id])
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('registrations', [
+        'participant_id' => $this->coach1->id,
+        'sub_category_id' => null,
+    ]);
+});
+
+test('unchecking coach removes registration', function () {
+    $this->actingAs($this->user);
+
+    // First select a coach to create registration, then uncheck it
+    Livewire::test(CoachSelectionForm::class)
+        ->set('selectedEventId', $this->event->id)
+        ->set('selectedCoachIds', [$this->coach1->id])
+        ->assertHasNoErrors()
+        ->set('selectedCoachIds', [])
+        ->assertHasNoErrors();
+
+    // Verify registration was soft-deleted
+    $this->assertDatabaseHas('registrations', [
+        'participant_id' => $this->coach1->id,
+    ]);
+    $this->assertSoftDeleted('registrations', [
+        'participant_id' => $this->coach1->id,
+    ]);
+});
+
+test('only shows open events', function () {
+    $this->actingAs($this->user);
+
+    $closedEvent = Event::create([
+        'name' => 'Test Event Closed',
+        'event_date' => now()->addDays(20),
+        'registration_deadline' => now()->subDays(1),
+        'status' => EventStatus::RegistrationClosed,
+        'coach_fee' => 50000,
+        'event_fee' => 100000,
+    ]);
+
+    Livewire::test(CoachSelectionForm::class)
+        ->set('selectedEventId', $closedEvent->id)
+        ->assertSet('selectedEventId', null)
+        ->assertSee('Event tidak valid atau pendaftaran sudah ditutup');
+});
+
+test('validates user has contingent', function () {
+    $userWithoutContingent = User::factory()->create(['username' => 'user_' . Str::random(5)]);
+
+    $this->actingAs($userWithoutContingent);
+
+    Livewire::test(CoachSelectionForm::class)
+        ->assertStatus(403);
+});
+
+test('shows only coaches from users contingent', function () {
+    $otherUser = User::factory()->create(['username' => 'user_' . Str::random(5)]);
+    $otherContingent = Contingent::create([
+        'user_id' => $otherUser->id,
+        'name' => 'Other Dojo',
+        'official_name' => 'Other Manager',
+        'phone' => '08987654321',
+        'address' => 'Other Address',
+    ]);
+    $otherCoach = Participant::factory()->create([
+        'type' => ParticipantType::Coach,
+        'contingent_id' => $otherContingent->id,
+        'photo' => 'other-coach.jpg',
+    ]);
+
+    $this->actingAs($this->user);
+
+    Livewire::test(CoachSelectionForm::class)
+        ->set('selectedEventId', $this->event->id)
+        ->assertSee($this->coach1->name)
+        ->assertSee($this->coach2->name)
+        ->assertDontSee($otherCoach->name);
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: ['resources/css/app.css', 'resources/css/registration.css', 'resources/js/app.js'],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
## Summary
This PR implements the Multi-Team Registration Engine for Beregu categories, allowing contingents to register more than one team in a single sub-category.

### Key Changes
- **Multi-Team Support**: Added max_teams configuration to sub-categories.
- **Team Management**: Created TeamGroup model and database structure to manage team metadata.
- **UI Updates**: Enhanced AthleteSelectionForm with a team management interface (create, delete, and select teams).
- **Validation**: Added cross-team validation to prevent athletes from joining multiple teams in the same category.
- **Invoice & Fees**: Updated EventRegistrationInvoice to calculate fees based on unique teams and include team association in final registrations.
- **Wizard Preview**: Updated registration wizard to show team counts in the draft summary.

> [!NOTE]
> This PR depends on #42.

Closes #37