### PR TITLE
Fix pagination styling on Livewire pages

### DIFF
--- a/resources/views/components/livewire-pagination.blade.php
+++ b/resources/views/components/livewire-pagination.blade.php
@@ -1,0 +1,50 @@
+@props(['paginator'])
+@php $elements = \Illuminate\Pagination\UrlWindow::make($paginator); @endphp
+
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">&lsaquo;</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="#" wire:click.prevent="previousPage" rel="prev" aria-label="Previous">&lsaquo;</a>
+                </li>
+            @endif
+
+            @foreach ($elements as $element)
+                @if (is_string($element))
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">{{ $element }}</span>
+                    </li>
+                @endif
+
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="page-item active" aria-current="page">
+                                <span class="page-link">{{ $page }}</span>
+                            </li>
+                        @else
+                            <li class="page-item">
+                                <a class="page-link" href="#" wire:click.prevent="gotoPage({{ $page }})">{{ $page }}</a>
+                            </li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="#" wire:click.prevent="nextPage" rel="next" aria-label="Next">&rsaquo;</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/livewire/admin/payment-management.blade.php
+++ b/resources/views/livewire/admin/payment-management.blade.php
@@ -130,7 +130,7 @@
                 </div>
 
                 <div class="mt-5">
-                    {{ $this->payments->links() }}
+                    <x-livewire-pagination :paginator="$this->payments" />
                 </div>
             </div>
         </div>

--- a/resources/views/livewire/participant-list.blade.php
+++ b/resources/views/livewire/participant-list.blade.php
@@ -237,7 +237,7 @@
                         </div>
                     </div>
                     <div class="col-sm-12 col-md-7 d-flex align-items-center justify-content-center justify-content-md-end">
-                        {{ $participants->links() }}
+                        <x-livewire-pagination :paginator="$participants" />
                     </div>
                 </div>
             @endif


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fix pagination yang tidak rapi di halaman Livewire (Daftar Peserta & Manajemen Pembayaran) — menggunakan Tailwind CSS bawaan Livewire v3, bukan Metronic/Bootstrap 5
- Buat komponen Blade `livewire-pagination` dengan styling Bootstrap 5 + `wire:click` Livewire
- Terapkan komponen di kedua halaman Livewire

## Test plan
- [ ] Buka halaman Daftar Peserta, verifikasi pagination tampil rapi dengan styling Metronic
- [ ] Navigasi antar halaman pagination berjalan tanpa reload
- [ ] Buka halaman Manajemen Pembayaran admin, verifikasi pagination sama rapi
- [ ] Test di mobile, pagination tetap responsive

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)