### PR TITLE
fix: correct Min Age calculation and sanitize CSV export values

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -266,6 +266,7 @@ class ReportController extends Controller
                 'event_categories.type',
                 'event_categories.class_name',
                 'event_categories.min_birth_date',
+                'event_categories.max_birth_date',
                 'events.name as event_name',
                 'team_groups.team_name',
                 'participants.is_verified',
@@ -381,6 +382,7 @@ class ReportController extends Controller
                 'event_categories.type',
                 'event_categories.class_name',
                 'event_categories.min_birth_date',
+                'event_categories.max_birth_date',
                 'events.name as event_name',
                 'team_groups.team_name',
                 'participants.is_verified',
@@ -469,6 +471,7 @@ class ReportController extends Controller
                 'event_categories.type',
                 'event_categories.class_name',
                 'event_categories.min_birth_date',
+                'event_categories.max_birth_date',
                 'events.name as event_name',
                 'team_groups.team_name',
                 'participants.is_verified',
@@ -609,9 +612,9 @@ class ReportController extends Controller
         // 11. Name Team (Nama team jika team = 't', else '')
         $registration->name_team = $registration->team === 't' ? ($registration->team_name ?? '') : '';
 
-        // 12. Min Age (Usia min dihitung dari min_birth_date event_categories ke tanggal laporan digenerate)
-        $registration->min_age = $registration->min_birth_date
-            ? \Carbon\Carbon::parse($registration->min_birth_date)->age
+        // 12. Min Age (usia termuda = usia dari max_birth_date; min_birth_date = usia tertua)
+        $registration->min_age = $registration->max_birth_date
+            ? \Carbon\Carbon::parse($registration->max_birth_date)->age
             : '-';
 
         // 13. Status Berkas (verified / rejected / pending)

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -424,7 +424,12 @@
 
                         const csvRows = [headers.join(',')];
                         data.forEach((p) => {
-                            const escapeCsv = (val) => `"${(val !== null && val !== undefined ? String(val) : '').replace(/"/g, '""')}"`;
+                            const escapeCsv = (val) => `"${String(val ?? '')
+                                .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+                                .replace(/\s+/g, ' ')
+                                .trim()
+                                .toLowerCase()
+                                .replace(/"/g, '""')}"`;
                             const row = [
                                 escapeCsv(p.invoice_number),
                                 escapeCsv(p.date_formatted),

--- a/resources/views/reports/participants.blade.php
+++ b/resources/views/reports/participants.blade.php
@@ -487,7 +487,12 @@
                         // Build CSV rows
                         const csvRows = [headers.join(',')];
                         data.forEach((reg) => {
-                            const escapeCsv = (val) => `"${(val !== null && val !== undefined ? String(val) : '').replace(/"/g, '""')}"`;
+                            const escapeCsv = (val) => `"${String(val ?? '')
+                                .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+                                .replace(/\s+/g, ' ')
+                                .trim()
+                                .toLowerCase()
+                                .replace(/"/g, '""')}"`;
                             const row = [
                                 escapeCsv(reg.full_name_kontingen),
                                 escapeCsv(reg.short_name_kontingen),


### PR DESCRIPTION
## Summary
- Fix Min Age column in participant reports: now computed from `max_birth_date` (youngest eligible age) instead of `min_birth_date` (oldest age), which mismatched the column name
- Select `max_birth_date` in all 3 report queries (page, CSV export, PDF)
- Sanitize CSV export values in financial and participant reports: strip special characters (Unicode-aware, keeps letters/digits/spaces/hyphens), collapse extra spaces, lowercase all values

## Test plan
- [ ] Open participant report, verify Min Age column shows youngest eligible age for each category
- [ ] Export participant CSV, verify no special characters and all lowercase values
- [ ] Export financial CSV, verify same sanitization
- [ ] Verify PDF report Min Age matches table

🤖 Generated with [Claude Code](https://claude.com/claude-code)