### PR TITLE
feat: event scoping (panitia manages assigned events) + certificate improvements

### DIFF
--- a/app/Http/Controllers/Admin/DocumentVerificationController.php
+++ b/app/Http/Controllers/Admin/DocumentVerificationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Enums\ParticipantType;
 use App\Enums\RegistrationStatus;
+use App\Enums\EventStatus;
 use App\Http\Controllers\Controller;
 use App\Models\ActivityLog;
 use App\Models\Participant;
@@ -15,6 +16,30 @@ use App\Http\Requests\Admin\RejectDocumentRequest;
 
 class DocumentVerificationController extends Controller
 {
+    /**
+     * Tolak aksi tulis bila panitia tidak mengelola event peserta ini,
+     * atau bila event peserta sudah completed (read-only).
+     */
+    private function guardScoped(Participant $participant): void
+    {
+        if (auth()->user()->hasRole('super-admin')) {
+            return;
+        }
+
+        $registrations = $participant->registrations()
+            ->forManagedEvents()
+            ->with('payment.event')
+            ->get();
+
+        abort_if($registrations->isEmpty(), 403, 'Peserta tidak ada di event yang ditugaskan.');
+
+        abort_if(
+            $registrations->contains(fn ($r) => $r->payment?->event?->status === EventStatus::Completed),
+            403,
+            'Event selesai, data read-only.'
+        );
+    }
+
     public function index(Request $request)
     {
         $query = Participant::with('contingent')
@@ -42,6 +67,11 @@ class DocumentVerificationController extends Controller
             });
         }
 
+        // Panitia hanya melihat peserta yang mendaftar event yang dipegangnya
+        if (auth()->user()->hasRole('panitia')) {
+            $query->whereHas('registrations', fn ($r) => $r->forManagedEvents());
+        }
+
         // Urutkan: Belum terverifikasi paling atas
         $query->orderBy('is_verified', 'asc')
               ->latest();
@@ -53,6 +83,8 @@ class DocumentVerificationController extends Controller
 
     public function approve(Request $request, Participant $participant)
     {
+        $this->guardScoped($participant);
+
         if ($participant->is_verified) {
             return response()->json(['message' => 'Peserta ini sudah diverifikasi sebelumnya.'], 400);
         }
@@ -68,7 +100,7 @@ class DocumentVerificationController extends Controller
                 ]);
 
                 // 2. Update Registrations
-                Registration::where('participant_id', $participant->id)->update([
+                Registration::forManagedEvents()->where('participant_id', $participant->id)->update([
                     'status_berkas' => RegistrationStatus::Verified->value,
                     'verified_at' => now(),
                     'verified_by' => auth()->id(),
@@ -100,6 +132,7 @@ class DocumentVerificationController extends Controller
 
     public function reject(RejectDocumentRequest $request, Participant $participant)
     {
+        $this->guardScoped($participant);
 
         try {
             DB::transaction(function () use ($request, $participant) {
@@ -112,7 +145,7 @@ class DocumentVerificationController extends Controller
                 ]);
 
                 // Update Registrations
-                Registration::where('participant_id', $participant->id)->update([
+                Registration::forManagedEvents()->where('participant_id', $participant->id)->update([
                     'status_berkas' => RegistrationStatus::Rejected->value,
                     'verified_at' => null,
                     'verified_by' => null,
@@ -143,6 +176,7 @@ class DocumentVerificationController extends Controller
 
     public function revoke(RejectDocumentRequest $request, Participant $participant)
     {
+        $this->guardScoped($participant);
 
         if (!$participant->is_verified) {
             return response()->json(['message' => 'Hanya peserta yang sudah terverifikasi yang bisa di-revoke.'], 400);
@@ -158,8 +192,8 @@ class DocumentVerificationController extends Controller
                     'rejection_reason' => $request->rejection_reason,
                 ]);
 
-                // 2. Reset Registrations status
-                Registration::where('participant_id', $participant->id)->update([
+                // 2. Reset Registrations status (hanya event yang dipegang panitia)
+                Registration::forManagedEvents()->where('participant_id', $participant->id)->update([
                     'status_berkas' => RegistrationStatus::PendingReview->value,
                     'verified_at' => null,
                     'verified_by' => null,

--- a/app/Http/Controllers/Admin/EventController.php
+++ b/app/Http/Controllers/Admin/EventController.php
@@ -70,7 +70,8 @@ class EventController extends Controller
     {
         $this->authorize('manage', $event);
 
-        $panitiaUsers = auth()->user()->hasRole('super-admin')
+        // Daftar panitia untuk penugasan hanya relevan bagi yang boleh assign
+        $panitiaUsers = auth()->user()->can('assign event panitia')
             ? User::role('panitia')->orderBy('name')->pluck('name', 'id')
             : collect();
 
@@ -142,7 +143,7 @@ class EventController extends Controller
     public function assignPanitia(Request $request, Event $event)
     {
         $this->authorize('manage', $event);
-        abort_unless(auth()->user()->hasRole('super-admin'), 403, 'Hanya super-admin yang bisa mengelola penugasan.');
+        $this->authorize('assign event panitia');
 
         $validated = $request->validate([
             'panitia_ids' => ['array'],

--- a/app/Http/Controllers/Admin/EventController.php
+++ b/app/Http/Controllers/Admin/EventController.php
@@ -6,6 +6,8 @@ use App\Enums\EventStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\EventRequest;
 use App\Models\Event;
+use App\Models\Scopes\ManagedEventScope;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -23,7 +25,9 @@ class EventController extends Controller
 
     public function index()
     {
-        $events = Event::query()
+        // Panitia tetap melihat semua event di daftar; tombol "Kelola"
+        // dikontrol policy (Tahap 4).
+        $events = Event::withoutGlobalScope(ManagedEventScope::class)
             ->select(['id', 'poster', 'name', 'status', 'event_fee'])
             ->orderByDesc('event_date')
             ->paginate(10)
@@ -49,6 +53,9 @@ class EventController extends Controller
 
         $event = Event::create($validated);
 
+        // Pembuat event otomatis tercatat sebagai panitia event itu (Tahap 5).
+        $event->panitia()->attach(auth()->id());
+
         return redirect()->route('admin.events.show', $event)->with('success', 'Event berhasil dibuat.');
     }
 
@@ -61,11 +68,19 @@ class EventController extends Controller
 
     public function edit(Event $event)
     {
-        return view('admin.events.edit', compact('event'));
+        $this->authorize('manage', $event);
+
+        $panitiaUsers = auth()->user()->hasRole('super-admin')
+            ? User::role('panitia')->orderBy('name')->pluck('name', 'id')
+            : collect();
+
+        return view('admin.events.edit', compact('event', 'panitiaUsers'));
     }
 
     public function update(EventRequest $request, Event $event)
     {
+        $this->authorize('manage', $event);
+
         $validated = $request->validated();
 
         if ($request->hasFile('poster')) {
@@ -88,6 +103,8 @@ class EventController extends Controller
 
     public function destroy(Event $event)
     {
+        $this->authorize('manage', $event);
+
         if ($event->categories()->exists() || $event->payments()->exists()) {
             return back()->withErrors([
                 'delete' => 'Event tidak dapat dihapus karena sudah memiliki kategori atau pembayaran.',
@@ -103,6 +120,8 @@ class EventController extends Controller
 
     public function transition(Request $request, Event $event)
     {
+        $this->authorize('manage', $event);
+
         $validated = $request->validate([
             'status' => ['required', Rule::enum(EventStatus::class)],
         ]);
@@ -118,6 +137,21 @@ class EventController extends Controller
         $event->update(['status' => $nextStatus]);
 
         return back()->with('success', 'Status event berhasil diubah.');
+    }
+
+    public function assignPanitia(Request $request, Event $event)
+    {
+        $this->authorize('manage', $event);
+        abort_unless(auth()->user()->hasRole('super-admin'), 403, 'Hanya super-admin yang bisa mengelola penugasan.');
+
+        $validated = $request->validate([
+            'panitia_ids' => ['array'],
+            'panitia_ids.*' => ['integer', 'exists:users,id'],
+        ]);
+
+        $event->panitia()->sync($validated['panitia_ids'] ?? []);
+
+        return back()->with('success', 'Penugasan panitia berhasil disimpan.');
     }
 
     private function storePoster(UploadedFile $file): string

--- a/app/Http/Controllers/CertificateController.php
+++ b/app/Http/Controllers/CertificateController.php
@@ -68,8 +68,11 @@ class CertificateController extends Controller
             'replacements' => [
                 '{nama}' => $registration->participant->name,
                 '{kategori}' => $entry['category'],
+                '{kelas}' => $entry['class'],
+                '{subkategori}' => $entry['sub_category'],
                 '{status}' => $entry['status'],
                 '{event}' => $entry['event']->name,
+                '{xxx}' => $this->service->sequenceNumber($registration),
                 '{kontingen}' => $registration->participant->contingent?->name ?? '',
             ],
         ])->setPaper('a4', $template->orientation);

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -50,17 +50,63 @@ class DashboardController extends Controller
         }
 
         // Fallback for Panitia or Observer/Viewer roles (shows general charts and totals)
-        $eventCharts = $this->getEventChartData();
+        // Event Scoping: statistik panitia dibatasi ke event yang dipegangnya.
+        $managedEvents = $user->managedEvents()->with(['categories.subCategories.registrations.payment'])->get();
+
+        if ($user->hasRole('panitia') && $managedEvents->isEmpty()) {
+            return view('dashboard.index', ['role' => 'panitia-empty']);
+        }
+
+        $eventIds = $managedEvents->pluck('id');
+
+        $managedPayments = \App\Models\Payment::whereIn('event_id', $eventIds)
+            ->where('status', 'pending')
+            ->with('registrations')
+            ->get();
+        $pendingRegistrationIds = $managedPayments->flatMap->registrations->pluck('participant_id')->unique();
+
+        $scopedAthletes = Participant::athletes()
+            ->whereHas('registrations.payment', fn ($q) => $q->whereIn('event_id', $eventIds))
+            ->count();
+        $scopedCoaches = Participant::coaches()
+            ->whereHas('registrations.payment', fn ($q) => $q->whereIn('event_id', $eventIds))
+            ->count();
+        $scopedOfficials = Participant::where('type', ParticipantType::Official)
+            ->whereHas('registrations.payment', fn ($q) => $q->whereIn('event_id', $eventIds))
+            ->count();
+        $scopedVerified = Participant::where('is_verified', true)
+            ->whereHas('registrations.payment', fn ($q) => $q->whereIn('event_id', $eventIds))
+            ->count();
+        $scopedKontingen = Contingent::whereHas('payments', fn ($q) => $q->whereIn('event_id', $eventIds))
+            ->count();
+
+        $eventCharts = $managedEvents
+            ->filter(fn ($event) => $event->status !== \App\Enums\EventStatus::Completed)
+            ->map(fn($event) => (object) [
+                'name' => $event->name,
+                'categories' => $event->categories->map(fn($cat) => (object) [
+                    'name' => $cat->class_name,
+                    'labels' => $cat->subCategories->pluck('name'),
+                    // fix = berkas verified + pembayaran verified (solid); pending = sisanya (shadow)
+                    'seriesFix' => $cat->subCategories->map(fn($sub) => $sub->registrations
+                        ->filter(fn($r) => $r->status_berkas === 'verified' && $r->payment?->status === 'verified')->count()),
+                    'seriesPending' => $cat->subCategories->map(fn($sub) => $sub->registrations
+                        ->reject(fn($r) => $r->status_berkas === 'verified' && $r->payment?->status === 'verified')->count()),
+                ]),
+            ])
+            ->values();
 
         return view('dashboard.index', [
             'role' => 'panitia',
-            'totalKontingen' => Contingent::count(),
-            'totalAthletes' => Participant::athletes()->count(),
-            'totalCoaches' => Participant::coaches()->count(),
-            'totalOfficials' => Participant::where('type', ParticipantType::Official)->count(),
-            'totalVerified' => Participant::where('is_verified', true)->count(),
-            'totalPending' => Participant::where('is_verified', false)->count(),
+            'totalKontingen' => $scopedKontingen,
+            'totalAthletes' => $scopedAthletes,
+            'totalCoaches' => $scopedCoaches,
+            'totalOfficials' => $scopedOfficials,
+            'totalVerified' => $scopedVerified,
+            'totalPending' => $pendingRegistrationIds->count(),
+            'pendingPayments' => $managedPayments->count(),
             'topKontingen' => Contingent::withCount('participants')
+                ->whereHas('payments', fn ($q) => $q->whereIn('event_id', $eventIds))
                 ->orderByDesc('participants_count')
                 ->take(10)
                 ->get(),

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -13,7 +13,7 @@ class ReportController extends Controller
 {
     public function index(Request $request)
     {
-        $query = Payment::with(['contingent', 'event', 'verifiedBy', 'registrations.subCategory']);
+        $query = Payment::forManagedEvents()->with(['contingent', 'event', 'verifiedBy', 'registrations.subCategory']);
 
         // Filter Event
         if ($request->filled('event')) {
@@ -106,7 +106,7 @@ class ReportController extends Controller
 
     public function financialExport(Request $request)
     {
-        $query = Payment::with(['contingent', 'event', 'verifiedBy', 'registrations.subCategory']);
+        $query = Payment::forManagedEvents()->with(['contingent', 'event', 'verifiedBy', 'registrations.subCategory']);
 
         if ($request->filled('event')) {
             $query->where('event_id', $request->event);
@@ -144,7 +144,7 @@ class ReportController extends Controller
 
     public function financialPdf(Request $request)
     {
-        $query = Payment::with(['contingent', 'event', 'verifiedBy', 'registrations.subCategory']);
+        $query = Payment::forManagedEvents()->with(['contingent', 'event', 'verifiedBy', 'registrations.subCategory']);
 
         $activeEvent = $request->filled('event') ? Event::find($request->event) : null;
         $activeContingent = $request->filled('contingent') ? Contingent::find($request->contingent) : null;
@@ -244,7 +244,7 @@ class ReportController extends Controller
     public function participants(Request $request)
     {
         // Build query with all necessary joins
-        $query = Registration::with(['participant.contingent', 'subCategory.eventCategory.event', 'teamGroup'])
+        $query = Registration::forManagedEvents()->with(['participant.contingent', 'subCategory.eventCategory.event', 'teamGroup'])
             ->whereNull('registrations.deleted_at')  // Exclude soft-deleted registrations
             ->whereNotNull('registrations.sub_category_id')  // Exclude coach registrations
             ->join('participants', 'participants.id', '=', 'registrations.participant_id')
@@ -360,7 +360,7 @@ class ReportController extends Controller
     public function participantsExport(Request $request)
     {
         // Build query with all necessary joins (same as participants method)
-        $query = Registration::with(['participant.contingent', 'subCategory.eventCategory.event', 'teamGroup'])
+        $query = Registration::forManagedEvents()->with(['participant.contingent', 'subCategory.eventCategory.event', 'teamGroup'])
             ->whereNull('registrations.deleted_at')
             ->whereNotNull('registrations.sub_category_id')
             ->join('participants', 'participants.id', '=', 'registrations.participant_id')
@@ -449,7 +449,7 @@ class ReportController extends Controller
     public function participantsPdf(Request $request)
     {
         // Build query with all necessary joins
-        $query = Registration::with(['participant.contingent', 'subCategory.eventCategory.event', 'teamGroup'])
+        $query = Registration::forManagedEvents()->with(['participant.contingent', 'subCategory.eventCategory.event', 'teamGroup'])
             ->whereNull('registrations.deleted_at')
             ->whereNotNull('registrations.sub_category_id')
             ->join('participants', 'participants.id', '=', 'registrations.participant_id')

--- a/app/Livewire/Admin/ParticipantManagement.php
+++ b/app/Livewire/Admin/ParticipantManagement.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin;
 
 use App\Enums\ParticipantType;
 use App\Enums\RegistrationStatus;
+use App\Enums\EventStatus;
 use App\Models\ActivityLog;
 use App\Models\Participant;
 use App\Models\Registration;
@@ -81,6 +82,13 @@ class ParticipantManagement extends Component
             ->when($this->verificationFilter !== '', function ($q) {
                 $q->where('is_verified', $this->verificationFilter === 'verified');
             })
+            // Panitia hanya melihat peserta yang mendaftar event yang dipegangnya
+            ->when(auth()->user()->hasRole('panitia'), function ($q) {
+                $q->whereHas(
+                    'registrations',
+                    fn ($r) => $r->forManagedEvents()
+                );
+            })
             ->when($this->provinceFilter, function ($q) {
                 $q->whereHas('contingent', fn($c) => $c->where('province', $this->provinceFilter));
             })
@@ -121,12 +129,32 @@ class ParticipantManagement extends Component
         $this->resetErrorBag();
     }
 
+    /**
+     * True bila peserta punya registrasi di event completed yang dipegang
+     * panitia ini — aksi tulis harus ditolak (super-admin lolos).
+     */
+    private function touchesCompletedEvent(Participant $participant): bool
+    {
+        if (auth()->user()->hasRole('super-admin')) {
+            return false;
+        }
+
+        return $participant->registrations
+            ->filter(fn ($r) => $r->payment?->event?->status === EventStatus::Completed)
+            ->isNotEmpty();
+    }
+
     public function approve()
     {
         if (!$this->selectedParticipantId) return;
 
-        $participant = Participant::findOrFail($this->selectedParticipantId);
-        
+        $participant = Participant::with('registrations.payment.event')->findOrFail($this->selectedParticipantId);
+
+        if ($this->touchesCompletedEvent($participant)) {
+            $this->dispatch('swal:error', message: 'Event selesai, data read-only.');
+            return;
+        }
+
         if ($participant->is_verified) {
             $this->dispatch('swal:error', message: 'Peserta ini sudah diverifikasi.');
             return;
@@ -141,7 +169,7 @@ class ParticipantManagement extends Component
                     'rejection_reason' => null,
                 ]);
 
-                Registration::where('participant_id', $participant->id)->update([
+                Registration::forManagedEvents()->where('participant_id', $participant->id)->update([
                     'status_berkas' => RegistrationStatus::Verified->value,
                     'verified_at' => now(),
                     'verified_by' => auth()->id(),
@@ -173,7 +201,12 @@ class ParticipantManagement extends Component
             'rejectionReason' => 'required|min:5',
         ]);
 
-        $participant = Participant::findOrFail($this->selectedParticipantId);
+        $participant = Participant::with('registrations.payment.event')->findOrFail($this->selectedParticipantId);
+
+        if ($this->touchesCompletedEvent($participant)) {
+            $this->dispatch('swal:error', message: 'Event selesai, data read-only.');
+            return;
+        }
 
         try {
             DB::transaction(function () use ($participant) {
@@ -184,7 +217,7 @@ class ParticipantManagement extends Component
                     'rejection_reason' => $this->rejectionReason,
                 ]);
 
-                Registration::where('participant_id', $participant->id)->update([
+                Registration::forManagedEvents()->where('participant_id', $participant->id)->update([
                     'status_berkas' => RegistrationStatus::Rejected->value,
                     'verified_at' => null,
                     'verified_by' => null,
@@ -216,7 +249,12 @@ class ParticipantManagement extends Component
             'rejectionReason' => 'required|min:5',
         ]);
 
-        $participant = Participant::findOrFail($this->selectedParticipantId);
+        $participant = Participant::with('registrations.payment.event')->findOrFail($this->selectedParticipantId);
+
+        if ($this->touchesCompletedEvent($participant)) {
+            $this->dispatch('swal:error', message: 'Event selesai, data read-only.');
+            return;
+        }
 
         if (!$participant->is_verified) {
             $this->dispatch('swal:error', message: 'Hanya peserta terverifikasi yang bisa di-revoke.');
@@ -232,7 +270,7 @@ class ParticipantManagement extends Component
                     'rejection_reason' => $this->rejectionReason,
                 ]);
 
-                Registration::where('participant_id', $participant->id)->update([
+                Registration::forManagedEvents()->where('participant_id', $participant->id)->update([
                     'status_berkas' => RegistrationStatus::PendingReview->value,
                     'verified_at' => null,
                     'verified_by' => null,

--- a/app/Livewire/Admin/PaymentManagement.php
+++ b/app/Livewire/Admin/PaymentManagement.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Admin;
 
 use App\Enums\PaymentStatus;
+use App\Enums\EventStatus;
 use App\Enums\RegistrationStatus;
 use App\Models\Payment;
 use App\Models\Registration;
@@ -88,6 +89,7 @@ class PaymentManagement extends Component
     public function payments()
     {
         return Payment::query()
+            ->forManagedEvents()
             ->with(['contingent' => function ($query) {
                 $query->withTrashed(); // Include soft-deleted contingents
             }, 'event', 'registrations.subCategory.eventCategory'])
@@ -136,7 +138,12 @@ class PaymentManagement extends Component
     {
         if (!$this->selectedPaymentId) return;
 
-        $payment = Payment::findOrFail($this->selectedPaymentId);
+        $payment = Payment::forManagedEvents()->findOrFail($this->selectedPaymentId);
+
+        if ($payment->event->status === EventStatus::Completed && !auth()->user()->hasRole('super-admin')) {
+            $this->dispatch('swal:error', message: 'Event selesai, data read-only.');
+            return;
+        }
 
         if ($payment->status !== PaymentStatus::Pending) {
             $this->dispatch('swal:error', message: 'Hanya pembayaran berstatus pending yang bisa disetujui.');
@@ -191,7 +198,12 @@ class PaymentManagement extends Component
             'rejectionReason.min' => 'Alasan penolakan minimal 5 karakter.',
         ]);
 
-        $payment = Payment::findOrFail($this->selectedPaymentId);
+        $payment = Payment::forManagedEvents()->findOrFail($this->selectedPaymentId);
+
+        if ($payment->event->status === EventStatus::Completed && !auth()->user()->hasRole('super-admin')) {
+            $this->dispatch('swal:error', message: 'Event selesai, data read-only.');
+            return;
+        }
 
         if ($payment->status !== PaymentStatus::Pending) {
             $this->dispatch('swal:error', message: 'Hanya pembayaran berstatus pending yang bisa ditolak.');
@@ -219,7 +231,12 @@ class PaymentManagement extends Component
             'rejectionReason.min' => 'Alasan revoke minimal 5 karakter.',
         ]);
 
-        $payment = Payment::findOrFail($this->selectedPaymentId);
+        $payment = Payment::forManagedEvents()->findOrFail($this->selectedPaymentId);
+
+        if ($payment->event->status === EventStatus::Completed && !auth()->user()->hasRole('super-admin')) {
+            $this->dispatch('swal:error', message: 'Event selesai, data read-only.');
+            return;
+        }
 
         if ($payment->status !== PaymentStatus::Verified) {
             $this->dispatch('swal:error', message: 'Hanya pembayaran berstatus verified yang bisa di-revoke.');
@@ -274,7 +291,12 @@ class PaymentManagement extends Component
 
     public function deletePayment(int $paymentId): void
     {
-        $payment = Payment::findOrFail($paymentId);
+        $payment = Payment::forManagedEvents()->findOrFail($paymentId);
+
+        if ($payment->event->status === EventStatus::Completed && !auth()->user()->hasRole('super-admin')) {
+            $this->dispatch('swal:error', message: 'Event selesai, data read-only.');
+            return;
+        }
 
         if ($payment->status === PaymentStatus::Verified) {
             $this->dispatch('swal:error', message: 'Pembayaran berstatus Verified tidak dapat langsung dihapus. Silakan Revoke statusnya terlebih dahulu jika benar-benar ingin menghapus.');

--- a/app/Livewire/Admin/ResultEntry.php
+++ b/app/Livewire/Admin/ResultEntry.php
@@ -17,6 +17,9 @@ class ResultEntry extends Component
 
     public function mount(Event $event)
     {
+        // Panitia hanya bisa input hasil event yang dipegangnya & belum completed
+        abort_unless(auth()->user()->can('manage', $event), 403, 'Bukan event yang ditugaskan.');
+
         $this->event = $event;
         $this->event->load([
             'categories.subCategories.registrations' => function ($q) {
@@ -86,6 +89,8 @@ class ResultEntry extends Component
 
     public function save($subCategoryId)
     {
+        abort_unless(auth()->user()->can('manage', $this->event), 403, 'Event selesai, data read-only.');
+
         $slots = $this->slots[$subCategoryId] ?? [];
         
         // Validate duplicates
@@ -95,7 +100,7 @@ class ResultEntry extends Component
             return;
         }
 
-        $subCategoryRegIds = Registration::where('sub_category_id', $subCategoryId)->pluck('id');
+        $subCategoryRegIds = Registration::forManagedEvents()->where('sub_category_id', $subCategoryId)->pluck('id');
         
         // Delete existing results for this subcategory
         Result::whereIn('registration_id', $subCategoryRegIds)->delete();

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -3,11 +3,15 @@
 namespace App\Models;
 
 use App\Enums\EventStatus;
+use App\Models\Scopes\ManagedEventScope;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Storage;
 
+#[ScopedBy(ManagedEventScope::class)]
 class Event extends Model
 {
     use HasFactory;
@@ -54,6 +58,11 @@ class Event extends Model
     public function certificateTemplates(): HasMany
     {
         return $this->hasMany(CertificateTemplate::class);
+    }
+
+    public function panitia(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'event_user');
     }
 
     public function allowedStatusTransitions(): array

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -59,6 +59,17 @@ class Payment extends Model
         return $this->status !== PaymentStatus::Cancelled;
     }
 
+    public function scopeForManagedEvents($query)
+    {
+        $user = auth()->user();
+
+        if (! $user || ! $user->hasRole('panitia')) {
+            return $query;
+        }
+
+        return $query->whereIn('event_id', $user->managedEvents()->pluck('events.id'));
+    }
+
     public function canUploadProof(): bool
     {
         return in_array($this->status, [PaymentStatus::Pending, PaymentStatus::Rejected]);

--- a/app/Models/Registration.php
+++ b/app/Models/Registration.php
@@ -66,4 +66,18 @@ class Registration extends Model
     {
         return $this->sub_category_id === null;
     }
+
+    public function scopeForManagedEvents($query)
+    {
+        $user = auth()->user();
+
+        if (! $user || ! $user->hasRole('panitia')) {
+            return $query;
+        }
+
+        return $query->whereHas(
+            'payment',
+            fn ($q) => $q->whereIn('event_id', $user->managedEvents()->pluck('events.id'))
+        );
+    }
 }

--- a/app/Models/Registration.php
+++ b/app/Models/Registration.php
@@ -18,6 +18,7 @@ class Registration extends Model
         'payment_id',
         'sub_category_id',
         'status_berkas',
+        'certificate_no',
         'rejection_reason',
         'verified_at',
         'verified_by',

--- a/app/Models/RegistrationDraft.php
+++ b/app/Models/RegistrationDraft.php
@@ -69,4 +69,15 @@ class RegistrationDraft extends Model
     {
         return $this->hasMany(RegistrationDraftItem::class);
     }
+
+    public function scopeForManagedEvents($query)
+    {
+        $user = auth()->user();
+
+        if (! $user || ! $user->hasRole('panitia')) {
+            return $query;
+        }
+
+        return $query->whereIn('event_id', $user->managedEvents()->pluck('events.id'));
+    }
 }

--- a/app/Models/Scopes/ManagedEventScope.php
+++ b/app/Models/Scopes/ManagedEventScope.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ManagedEventScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $user = auth()->user();
+
+        // Guest, super-admin, kontingen, role lain → tanpa saringan.
+        // Hanya panitia yang dibatasi ke event yang ditugaskan.
+        if (! $user || ! $user->hasRole('panitia')) {
+            return;
+        }
+
+        $builder->whereHas('panitia', fn ($q) => $q->where('users.id', $user->id));
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -52,6 +53,16 @@ class User extends Authenticatable
     public function contingent(): HasOne
     {
         return $this->hasOne(Contingent::class);
+    }
+
+    public function managedEvents(): BelongsToMany
+    {
+        return $this->belongsToMany(Event::class, 'event_user');
+    }
+
+    public function managesEvent(Event $event): bool
+    {
+        return $this->managedEvents()->where('event_id', $event->id)->exists();
     }
 
     public function verifiedParticipants(): HasMany

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\EventStatus;
+use App\Models\Event;
+use App\Models\User;
+
+class EventPolicy
+{
+    public function manage(User $user, Event $event): bool
+    {
+        if ($user->hasRole('super-admin')) {
+            return true;
+        }
+
+        // Event completed → read-only untuk panitia
+        if ($event->status === EventStatus::Completed) {
+            return false;
+        }
+
+        return $user->hasRole('panitia') && $user->managesEvent($event);
+    }
+
+    public function view(User $user, Event $event): bool
+    {
+        return $user->hasRole(['super-admin', 'panitia']);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,8 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\View;
+use App\Models\Event;
+use App\Policies\EventPolicy;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -25,6 +27,7 @@ class AppServiceProvider extends ServiceProvider
         Gate::before(function ($user, $ability) {
             return $user->hasRole('super-admin') ? true : null;
         });
+        Gate::policy(Event::class, EventPolicy::class);
         Paginator::useBootstrapFive();
 
         View::composer('participants.*', function ($view) {

--- a/app/Services/CertificateService.php
+++ b/app/Services/CertificateService.php
@@ -35,11 +35,46 @@ class CertificateService
             ->map(fn (Registration $r) => [
                 'registration' => $r,
                 'event'        => $r->subCategory->eventCategory->event,
-                'category'     => $r->subCategory->eventCategory->class_name . ' — ' . $r->subCategory->name,
+                'category'     => $r->subCategory->eventCategory->type->value,
+                'class'        => $r->subCategory->eventCategory->class_name,
+                'sub_category' => $r->subCategory->name,
                 'status'       => $this->statusText($r),
                 'scope'        => $this->scopeFor($r),
             ])
             ->values();
+    }
+
+    /**
+     * Nomor urut sertifikat dalam satu event — untuk placeholder {xxx} pada
+     * format nomor buatan panitia (mis. "apr/7yh652/260829/{xxx}" → 001, 002, …).
+     * Diisi SEKALI saat generate PDF pertama lalu disimpan ke kolom
+     * certificate_no — unduh ulang / hapus registration lain tidak menggeser
+     * nomor yang sudah tercetak.
+     */
+    public function sequenceNumber(Registration $r): string
+    {
+        if ($r->certificate_no) {
+            return str_pad((string) $r->certificate_no, 3, '0', STR_PAD_LEFT);
+        }
+
+        $event = $r->subCategory?->eventCategory?->event;
+
+        if (! $event) {
+            return '001';
+        }
+
+        $rank = Registration::query()
+            ->whereNotNull('sub_category_id')
+            ->whereHas('payment', fn ($q) => $q->where('status', 'verified'))
+            ->whereHas('subCategory.eventCategory', fn ($q) => $q->where('event_id', $event->id))
+            ->orderBy('id')
+            ->pluck('id')
+            ->search($r->id);
+
+        $r->certificate_no = $rank + 1;
+        $r->save();
+
+        return str_pad((string) $r->certificate_no, 3, '0', STR_PAD_LEFT);
     }
 
     public function statusText(Registration $r): string

--- a/database/migrations/2026_08_27_000001_create_event_user_table.php
+++ b/database/migrations/2026_08_27_000001_create_event_user_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('event_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['event_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('event_user');
+    }
+};

--- a/database/migrations/2026_08_27_000002_add_certificate_no_to_registrations_table.php
+++ b/database/migrations/2026_08_27_000002_add_certificate_no_to_registrations_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Nomor urut sertifikat per event — diisi SEKALI saat generate PDF pertama
+     * (placeholder {xxx}), lalu terkunci: hapus/ubah registration lain tidak
+     * menggeser nomor yang sudah tercetak.
+     */
+    public function up(): void
+    {
+        Schema::table('registrations', function (Blueprint $table) {
+            $table->unsignedInteger('certificate_no')->nullable()->after('status_berkas');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('registrations', function (Blueprint $table) {
+            $table->dropColumn('certificate_no');
+        });
+    }
+};

--- a/database/seeders/Auth/RolesAndPermissionsSeeder.php
+++ b/database/seeders/Auth/RolesAndPermissionsSeeder.php
@@ -51,6 +51,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'delete events',
             'transition events',
             'manage events',
+            'assign event panitia',
             'manage event files',
             'manage event categories',
             'manage sub-categories',

--- a/database/seeders/EventSeeder.php
+++ b/database/seeders/EventSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Event;
 use App\Models\EventCategory;
 use App\Models\SubCategory;
+use App\Models\User;
 use Illuminate\Database\Seeder;
 
 class EventSeeder extends Seeder
@@ -222,7 +223,23 @@ class EventSeeder extends Seeder
             $this->seedCategoriesForEvent($event);
         }
 
+        $this->seedPanitiaAssignments();
+
         $this->command->info('EventSeeder: ' . count($events) . ' events created, each with Categories and SubCategories.');
+    }
+
+    /**
+     * Demo penugasan panitia (Tahap 10 event-scoping): panitia demo pertama
+     * ditugaskan ke event demo pertama. Idempoten via syncWithoutDetaching.
+     */
+    private function seedPanitiaAssignments(): void
+    {
+        $event = Event::first();
+        $panitia = User::role('panitia')->first();
+
+        if ($event && $panitia) {
+            $event->panitia()->syncWithoutDetaching([$panitia->id]);
+        }
     }
 
     private function seedCategoriesForEvent(Event $event): void

--- a/resources/views/admin/events/edit.blade.php
+++ b/resources/views/admin/events/edit.blade.php
@@ -27,6 +27,36 @@
                     <button type="submit" class="btn btn-primary">Simpan Perubahan</button>
                 </div>
             </form>
+
+            @if (auth()->user()->hasRole('super-admin'))
+                <div class="separator separator-dashed my-8"></div>
+
+                <form action="{{ route('admin.events.panitia.assign', $event) }}" method="POST"
+                    class="form">
+                    @csrf
+                    @method('PUT')
+                    <div class="row mb-6">
+                        <label class="col-lg-3 col-form-label fw-semibold">Panitia Event</label>
+                        <div class="col-lg-9">
+                            <p class="text-muted fs-7 mb-3">Panitia yang ditugaskan bisa mengelola event ini
+                                (verifikasi pembayaran &amp; berkas, input hasil). Panitia lain hanya bisa melihat.</p>
+                            <select class="form-select" name="panitia_ids[]" multiple size="8">
+                                @foreach ($panitiaUsers as $id => $name)
+                                    <option value="{{ $id }}"
+                                        {{ $event->panitia->contains('id', $id) ? 'selected' : '' }}>
+                                        {{ $name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            <div class="mt-6">
+                                <button type="submit" class="btn btn-light-primary">
+                                    <i class="bi bi-people"></i> Simpan Penugasan
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            @endif
         </div>
     </div>
 

--- a/resources/views/admin/events/edit.blade.php
+++ b/resources/views/admin/events/edit.blade.php
@@ -28,8 +28,8 @@
                 </div>
             </form>
 
-            @if (auth()->user()->hasRole('super-admin'))
-                <div class="separator separator-dashed my-8"></div>
+            @can('assign event panitia')
+                <div class="separator separator-dashed my-8" id="panitia"></div>
 
                 <form action="{{ route('admin.events.panitia.assign', $event) }}" method="POST"
                     class="form">
@@ -40,14 +40,37 @@
                         <div class="col-lg-9">
                             <p class="text-muted fs-7 mb-3">Panitia yang ditugaskan bisa mengelola event ini
                                 (verifikasi pembayaran &amp; berkas, input hasil). Panitia lain hanya bisa melihat.</p>
-                            <select class="form-select" name="panitia_ids[]" multiple size="8">
+
+                            @if ($event->panitia->isNotEmpty())
+                                <div class="d-flex flex-wrap align-items-center gap-2 mb-4">
+                                    <span class="text-muted fs-7">Sudah ditugaskan ({{ $event->panitia->count() }}):</span>
+                                    @foreach ($event->panitia as $p)
+                                        <span class="badge badge-light-primary fs-7">
+                                            <i class="bi bi-person-check fs-8 me-1"></i>{{ $p->name }}
+                                        </span>
+                                    @endforeach
+                                </div>
+                            @else
+                                <div class="text-muted fs-7 mb-4">
+                                    <i class="bi bi-info-circle me-1"></i>Belum ada panitia yang ditugaskan.
+                                </div>
+                            @endif
+
+                            <div class="border rounded p-4" style="max-height: 260px; overflow-y: auto">
                                 @foreach ($panitiaUsers as $id => $name)
-                                    <option value="{{ $id }}"
-                                        {{ $event->panitia->contains('id', $id) ? 'selected' : '' }}>
-                                        {{ $name }}
-                                    </option>
+                                    <label class="d-flex align-items-center py-2 {{ !$loop->last ? 'border-bottom' : '' }} cursor-pointer">
+                                        <input type="checkbox" name="panitia_ids[]" value="{{ $id }}"
+                                            class="form-check-input me-3"
+                                            {{ $event->panitia->contains('id', $id) ? 'checked' : '' }}>
+                                        <span class="fs-6">{{ $name }}</span>
+                                        @if ($event->panitia->contains('id', $id))
+                                            <span class="badge badge-light-success ms-2">Aktif</span>
+                                        @endif
+                                    </label>
                                 @endforeach
-                            </select>
+                            </div>
+                            <div class="form-text fs-8 mt-2">Centang = ditugaskan. Simpan untuk menerapkan perubahan.</div>
+
                             <div class="mt-6">
                                 <button type="submit" class="btn btn-light-primary">
                                     <i class="bi bi-people"></i> Simpan Penugasan

--- a/resources/views/admin/events/index.blade.php
+++ b/resources/views/admin/events/index.blade.php
@@ -63,19 +63,26 @@
                                             aria-label="Detail">
                                             <i class="bi bi-eye"></i>
                                         </a>
-                                        <a href="{{ route('admin.events.edit', $event) }}"
-                                            class="btn btn-icon btn-light-warning btn-sm" title="Edit"
-                                            aria-label="Edit">
-                                            <i class="bi bi-pencil-square"></i>
-                                        </a>
-                                        <form action="{{ route('admin.events.destroy', $event) }}" method="POST"
-                                            onsubmit="return confirm('Hapus event ini?')">
-                                            @csrf @method('DELETE')
-                                            <button type="submit" class="btn btn-icon btn-light-danger btn-sm"
-                                                title="Hapus" aria-label="Hapus">
-                                                <i class="bi bi-trash"></i>
+                                        @can('manage', $event)
+                                            <a href="{{ route('admin.events.edit', $event) }}"
+                                                class="btn btn-icon btn-light-warning btn-sm" title="Edit"
+                                                aria-label="Edit">
+                                                <i class="bi bi-pencil-square"></i>
+                                            </a>
+                                            <form action="{{ route('admin.events.destroy', $event) }}" method="POST"
+                                                onsubmit="return confirm('Hapus event ini?')">
+                                                @csrf @method('DELETE')
+                                                <button type="submit" class="btn btn-icon btn-light-danger btn-sm"
+                                                    title="Hapus" aria-label="Hapus">
+                                                    <i class="bi bi-trash"></i>
+                                                </button>
+                                            </form>
+                                        @else
+                                            <button type="button" class="btn btn-icon btn-light btn-sm" disabled
+                                                title="Bukan event yang ditugaskan / event selesai" aria-label="Kelola">
+                                                <i class="bi bi-lock"></i>
                                             </button>
-                                        </form>
+                                        @endcan
                                     </div>
                                 </td>
                             </tr>
@@ -114,18 +121,25 @@
                                     class="btn btn-icon btn-light-primary" title="Detail" aria-label="Detail">
                                     <i class="bi bi-eye"></i>
                                 </a>
-                                <a href="{{ route('admin.events.edit', $event) }}"
-                                    class="btn btn-icon btn-light-warning" title="Edit" aria-label="Edit">
-                                    <i class="bi bi-pencil-square"></i>
-                                </a>
-                                <form action="{{ route('admin.events.destroy', $event) }}" method="POST"
-                                    onsubmit="return confirm('Hapus event ini?')">
-                                    @csrf @method('DELETE')
-                                    <button type="submit" class="btn btn-icon btn-light-danger" title="Hapus"
-                                        aria-label="Hapus">
-                                        <i class="bi bi-trash"></i>
+                                @can('manage', $event)
+                                    <a href="{{ route('admin.events.edit', $event) }}"
+                                        class="btn btn-icon btn-light-warning" title="Edit" aria-label="Edit">
+                                        <i class="bi bi-pencil-square"></i>
+                                    </a>
+                                    <form action="{{ route('admin.events.destroy', $event) }}" method="POST"
+                                        onsubmit="return confirm('Hapus event ini?')">
+                                        @csrf @method('DELETE')
+                                        <button type="submit" class="btn btn-icon btn-light-danger" title="Hapus"
+                                            aria-label="Hapus">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </form>
+                                @else
+                                    <button type="button" class="btn btn-icon btn-light" disabled
+                                        title="Bukan event yang ditugaskan / event selesai" aria-label="Kelola">
+                                        <i class="bi bi-lock"></i>
                                     </button>
-                                </form>
+                                @endcan
                             </div>
                         </div>
                     </div>

--- a/resources/views/admin/events/show.blade.php
+++ b/resources/views/admin/events/show.blade.php
@@ -196,6 +196,25 @@
                     <div class="fw-bold"><span
                             class="badge {{ $event->statusBadgeClass() }}">{{ $event->statusLabel() }}</span></div>
                 </div>
+                <div class="col-md-6">
+                    <div class="text-muted fs-7">Panitia Ditugaskan</div>
+                    @if ($event->panitia->isNotEmpty())
+                        <div class="d-flex flex-wrap gap-2 mt-1">
+                            @foreach ($event->panitia as $p)
+                                <span class="badge badge-light-primary">
+                                    <i class="bi bi-person-check me-1"></i>{{ $p->name }}
+                                </span>
+                            @endforeach
+                        </div>
+                    @else
+                        <div class="fw-bold text-muted">Belum ada — @can('assign event panitia')
+                            <a href="{{ route('admin.events.edit', $event) }}#panitia" class="fw-bolder">tugaskan sekarang</a>
+                        @else
+                            hubungi super-admin
+                        @endcan
+                        </div>
+                    @endif
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/admin/results/index.blade.php
+++ b/resources/views/admin/results/index.blade.php
@@ -28,9 +28,15 @@
                                 </td>
                                 <td>{{ $event->formatted_date }}</td>
                                 <td class="text-end">
-                                    <a href="{{ route('admin.events.results.entry', $event) }}" class="btn btn-primary btn-sm">
-                                        <i class="bi bi-pencil-square"></i> Input Hasil
-                                    </a>
+                                    @can('manage', $event)
+                                        <a href="{{ route('admin.events.results.entry', $event) }}" class="btn btn-primary btn-sm">
+                                            <i class="bi bi-pencil-square"></i> Input Hasil
+                                        </a>
+                                    @else
+                                        <button type="button" class="btn btn-light btn-sm" disabled>
+                                            <i class="bi bi-lock"></i> Event Selesai / Bukan Tugas Anda
+                                        </button>
+                                    @endcan
                                     @can('manage certificate templates')
                                         <a href="{{ route('admin.events.certificate-templates.index', $event) }}" class="btn btn-light-primary btn-sm">
                                             <i class="bi bi-award"></i> Template Sertifikat

--- a/resources/views/certificates/result.blade.php
+++ b/resources/views/certificates/result.blade.php
@@ -116,7 +116,7 @@
                             <div class="flex items-start justify-between gap-sm">
                                 <div>
                                     <p class="font-label-bold text-primary uppercase mb-xs">{{ $cert['event']->name }}</p>
-                                    <p class="font-body-lg">{{ $cert['category'] }}</p>
+                                    <p class="font-body-lg">{{ $cert['class'] }} — {{ $cert['sub_category'] }}</p>
                                 </div>
                                 <span class="inline-flex items-center gap-xs border-2 border-on-background px-sm py-xs font-label-bold uppercase whitespace-nowrap">
                                     <span class="material-symbols-outlined text-lg" style="color: {{ $rail }};">military_tech</span>

--- a/resources/views/dashboard/components/panitia-empty.blade.php
+++ b/resources/views/dashboard/components/panitia-empty.blade.php
@@ -1,0 +1,18 @@
+<div class="card">
+    <div class="card-body p-0">
+        <div class="d-flex flex-column flex-center text-center py-20">
+            <img src="{{ asset('assets/media/logos/logo3.png') }}" alt="" class="mw-100px mb-8" style="filter: grayscale(1); opacity: .5">
+            <h3 class="fs-2 fw-bold text-gray-800 mb-2">Belum Ada Event yang Ditugaskan</h3>
+            <p class="text-muted fs-6 mb-8">
+                Anda belum ditugaskan sebagai panitia pada event apa pun.<br>
+                Hubungi <strong>super-admin</strong> untuk mendapatkan penugasan event, atau buat event baru
+                — event yang Anda buat otomatis menjadi tanggungan Anda.
+            </p>
+            @can('create', \App\Models\Event::class)
+                <a href="{{ route('admin.events.create') }}" class="btn btn-primary">
+                    <i class="bi bi-plus-lg"></i> Buat Event Baru
+                </a>
+            @endcan
+        </div>
+    </div>
+</div>

--- a/resources/views/dashboard/components/panitia.blade.php
+++ b/resources/views/dashboard/components/panitia.blade.php
@@ -12,8 +12,8 @@
                 <div class="alert alert-light d-flex align-items-center p-5 mb-0">
                     <i class="bi bi-info-circle-fill text-primary fs-3 me-4"></i>
                     <div class="d-flex flex-column">
-                        <span class="fw-bold">Ringkasan Data Event</span>
-                        <span class="text-muted fs-7">Berikut adalah statistik terkini peserta dan kontingen.</span>
+                        <span class="fw-bold">Ringkasan Data Event yang Ditugaskan</span>
+                        <span class="text-muted fs-7">Statistik berikut hanya mencakup event yang ditugaskan kepada Anda.</span>
                     </div>
                 </div>
             </div>

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -5,6 +5,8 @@
         @include('dashboard.components.super-admin')
     @elseif(($role ?? '') === 'panitia')
         @include('dashboard.components.panitia')
+    @elseif(($role ?? '') === 'panitia-empty')
+        @include('dashboard.components.panitia-empty')
     @else
         @include('dashboard.components.kontingen')
     @endif

--- a/resources/views/event-detail.blade.php
+++ b/resources/views/event-detail.blade.php
@@ -72,6 +72,7 @@
         <div class="hidden md:flex gap-lg items-center">
             <a class="font-label-bold text-label-bold text-on-background hover:border-b-4 hover:border-accent transition-all duration-100 ease-in-out px-xs" href="{{ route('landing') }}#events">TOURNAMENTS</a>
             <a class="font-label-bold text-label-bold text-on-background hover:border-b-4 hover:border-accent transition-all duration-100 ease-in-out px-xs" href="{{ route('landing') }}#about">ABOUT</a>
+            <a class="font-label-bold text-label-bold text-on-background hover:border-b-4 hover:border-accent transition-all duration-100 ease-in-out px-xs" href="{{ route('certificates.public.index') }}">CEK SERTIFIKAT</a>
             <a class="font-label-bold text-label-bold text-on-background hover:border-b-4 hover:border-accent transition-all duration-100 ease-in-out px-xs" href="{{ route('landing') }}#contact">CONTACT</a>
         </div>
         @guest
@@ -104,15 +105,19 @@
             <p class="font-headline-md text-primary mb-lg uppercase">
                 {{ $event->formatted_date }} <span class="text-surface-variant">· Lokasi akan diumumkan</span>
             </p>
-            <div class="flex flex-col sm:flex-row gap-md mt-lg">
+            <div class="flex flex-wrap gap-md mt-lg">
                 <a href="{{ $ctaHref }}"
-                   class="bg-primary text-on-primary font-display-lg text-headline-md px-lg py-sm h-16 hard-shadow-red hover:bg-white hover:text-on-background transition-all transform active:translate-y-1 flex items-center justify-center text-center">
+                   class="bg-primary text-on-primary font-display-lg text-lg uppercase tracking-wide px-xl py-sm rounded-lg border-2 border-on-background hover:bg-white hover:text-on-background transition-all flex items-center">
                     {{ $ctaLabel }}
                 </a>
                 <a href="{{ route('events.klasemen', $event->id) }}"
                    style="background-color: #FFD700;"
-                   class="text-black font-display-lg text-headline-md px-lg py-sm h-16 border-2 border-on-background hard-shadow hover:bg-on-background hover:text-white transition-all transform active:translate-y-1 flex items-center justify-center text-center uppercase">
-                    LIHAT KLASEMEN
+                   class="text-black font-display-lg text-lg uppercase tracking-wide px-xl py-sm rounded-lg border-2 border-on-background hover:bg-on-background hover:text-white transition-all flex items-center">
+                    Lihat Klasemen
+                </a>
+                <a href="{{ route('certificates.public.index') }}"
+                   class="bg-white text-on-background font-display-lg text-lg uppercase tracking-wide px-xl py-sm rounded-lg border-2 border-on-background hover:bg-primary hover:text-white hover:border-primary transition-all flex items-center">
+                    Cek Sertifikat
                 </a>
             </div>
         </div>

--- a/resources/views/livewire/admin/certificate-template-management.blade.php
+++ b/resources/views/livewire/admin/certificate-template-management.blade.php
@@ -133,7 +133,7 @@
                                 </button>
                             </div>
                             <div class="fs-8 text-muted mb-3">
-                                Placeholder: <code>{nama}</code> <code>{kategori}</code> <code>{status}</code> <code>{event}</code> <code>{kontingen}</code> — dicampur teks bebas.
+                                Placeholder: <code>{nama}</code> <code>{kategori}</code> <code>{kelas}</code> <code>{subkategori}</code> <code>{status}</code> <code>{event}</code> <code>{kontingen}</code> — dicampur teks bebas. Nomor sertifikat: tulis format bebas lalu sisipkan <code>{xxx}</code> untuk nomor urut, mis. <code>apr/7yh652/260829/{xxx}</code>.
                             </div>
                             @foreach ($texts as $i => $t)
                                 <div class="border rounded p-3 mb-3">
@@ -207,7 +207,10 @@
                                         @php
                                             $sample = strtr($t['content'], [
                                                 '{nama}' => 'CONTOH NAMA PESERTA',
-                                                '{kategori}' => 'Kelas — Sub Kategori',
+                                                '{kategori}' => 'Open',
+                                        '{kelas}' => 'DEWASA',
+                                        '{subkategori}' => 'KATA Individu Putra',
+                                        '{xxx}' => '001',
                                                 '{status}' => 'JUARA 1',
                                                 '{event}' => $event->name,
                                                 '{kontingen}' => 'Nama Kontingen',

--- a/resources/views/participants/show.blade.php
+++ b/resources/views/participants/show.blade.php
@@ -410,7 +410,7 @@
                                 @foreach ($certificates as $cert)
                                     <tr>
                                         <td class="text-gray-800 fw-bold">{{ $cert['event']->name }}</td>
-                                        <td class="text-gray-600">{{ $cert['category'] }}</td>
+                                        <td class="text-gray-600">{{ $cert['class'] }} — {{ $cert['sub_category'] }}</td>
                                         <td>
                                             @if ($cert['scope']->value === 'champion_gold')
                                                 <span class="badge badge-light-warning"><i class="bi bi-medal-fill me-1"></i>{{ $cert['status'] }}</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,6 +92,7 @@ Route::middleware('auth')->group(function () {
 
         Route::middleware(['permission:transition events'])->group(function () {
             Route::patch('events/{event}/transition', [EventController::class, 'transition'])->name('events.transition');
+            Route::put('events/{event}/panitia', [EventController::class, 'assignPanitia'])->name('events.panitia.assign');
         });
 
         Route::middleware(['permission:manage event files'])->group(function () {

--- a/tests/Feature/CertificatePublicTest.php
+++ b/tests/Feature/CertificatePublicTest.php
@@ -73,6 +73,7 @@ class CertificatePublicTest extends TestCase
             'texts' => [
                 ['content' => '{nama}', 'x' => 50, 'y' => 40, 'font_size' => 5, 'bold' => true, 'font_family' => 'greatvibes', 'color' => '#1a5276'],
                 ['content' => 'Festival {event} — {kontingen}', 'x' => 50, 'y' => 60, 'font_size' => 3, 'bold' => false, 'font_family' => 'dancingscript', 'color' => '#000000'],
+                ['content' => 'No. apr/7yh652/260829/{xxx}', 'x' => 50, 'y' => 90, 'font_size' => 2, 'bold' => false, 'font_family' => 'helvetica', 'color' => '#000000'],
             ],
         ]);
 

--- a/tests/Feature/EventScopingTest.php
+++ b/tests/Feature/EventScopingTest.php
@@ -34,7 +34,8 @@ class EventScopingTest extends TestCase
         }
 
         // Samakan permission panitia dengan RolesAndPermissionsSeeder agar
-        // lolos middleware permission di route admin.
+        // lolos middleware permission di route admin. Catatan: 'assign event
+        // panitia' sengaja TIDAK diberikan — penugasan panitia hanya super-admin.
         $panitiaPermissions = [
             'view dashboard', 'view events', 'create events', 'edit events', 'delete events',
             'transition events', 'manage events', 'manage event categories', 'manage sub-categories',
@@ -201,13 +202,20 @@ class EventScopingTest extends TestCase
     }
 
     #[Test]
-    public function panitia_cannot_use_assign_endpoint(): void
+    public function panitia_cannot_assign_panitia(): void
     {
+        // Assign panitia hanya untuk pemegang permission 'assign event panitia'
+        // (praktisnya super-admin); panitia biasa ditolak meski di event sendiri.
         $this->actingAs($this->panitiaA)
             ->put(route('admin.events.panitia.assign', $this->event1), [
-                'panitia_ids' => [],
+                'panitia_ids' => [$this->panitiaA->id, $this->panitiaB->id],
             ])
             ->assertForbidden();
+
+        $this->assertSame(
+            [$this->panitiaA->id],
+            $this->event1->panitia()->pluck('user_id')->all()
+        );
     }
 
     #[Test]

--- a/tests/Feature/EventScopingTest.php
+++ b/tests/Feature/EventScopingTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\EventStatus;
+use App\Models\Contingent;
+use App\Models\Event;
+use App\Models\Payment;
+use App\Models\Registration;
+use App\Models\SubCategory;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\BuildsCertificates;
+use Tests\TestCase;
+
+class EventScopingTest extends TestCase
+{
+    use BuildsCertificates, RefreshDatabase;
+
+    private User $superAdmin;
+    private User $panitiaA;
+    private User $panitiaB;
+    private User $kontingen;
+    private Event $event1;
+    private Event $event2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (['super-admin', 'panitia', 'kontingen'] as $role) {
+            \Spatie\Permission\Models\Role::firstOrCreate(['name' => $role, 'guard_name' => 'web']);
+        }
+
+        // Samakan permission panitia dengan RolesAndPermissionsSeeder agar
+        // lolos middleware permission di route admin.
+        $panitiaPermissions = [
+            'view dashboard', 'view events', 'create events', 'edit events', 'delete events',
+            'transition events', 'manage events', 'manage event categories', 'manage sub-categories',
+            'manage participants', 'verify payments', 'verify documents', 'manage registrations',
+            'view registrations', 'edit registrations', 'delete registrations', 'view reports',
+            'manage results', 'manage event files', 'export reports',
+        ];
+        foreach ($panitiaPermissions as $perm) {
+            \Spatie\Permission\Models\Permission::firstOrCreate(['name' => $perm, 'guard_name' => 'web']);
+        }
+
+        $this->superAdmin = User::factory()->create()->assignRole('super-admin');
+        $this->panitiaA = User::factory()->create()->assignRole('panitia');
+        $this->panitiaB = User::factory()->create()->assignRole('panitia');
+        $this->panitiaA->givePermissionTo($panitiaPermissions);
+        $this->panitiaB->givePermissionTo($panitiaPermissions);
+
+        $kontingenUser = User::factory()->create()->assignRole('kontingen');
+        $kontingenUser->contingent()->create([
+            'name' => 'Kontingen Test',
+            'official_name' => 'Kontingen Test Official',
+        ]);
+        $this->kontingen = $kontingenUser;
+
+        $this->event1 = Event::factory()->create(['name' => 'Event Satu']);
+        $this->event2 = Event::factory()->create(['name' => 'Event Dua']);
+
+        $this->event1->panitia()->attach($this->panitiaA->id);
+        $this->event2->panitia()->attach($this->panitiaB->id);
+    }
+
+    #[Test]
+    public function panitia_query_only_returns_assigned_events(): void
+    {
+        $this->actingAs($this->panitiaA);
+
+        $this->assertSame(['Event Satu'], Event::pluck('name')->all());
+    }
+
+    #[Test]
+    public function super_admin_sees_all_events(): void
+    {
+        $this->actingAs($this->superAdmin);
+
+        $this->assertSame(2, Event::count());
+    }
+
+    #[Test]
+    public function kontingen_sees_all_events(): void
+    {
+        $this->actingAs($this->kontingen);
+
+        $this->assertSame(2, Event::count());
+    }
+
+    #[Test]
+    public function guest_sees_all_events(): void
+    {
+        $this->assertSame(2, Event::count());
+    }
+
+    #[Test]
+    public function payments_scoped_to_managed_events(): void
+    {
+        $payment1 = $this->makePaymentFor($this->event1);
+        $this->makePaymentFor($this->event2);
+
+        $this->actingAs($this->panitiaA);
+
+        $this->assertSame([$payment1->id], Payment::forManagedEvents()->pluck('id')->all());
+
+        $this->actingAs($this->superAdmin);
+        $this->assertSame(2, Payment::forManagedEvents()->count());
+    }
+
+    #[Test]
+    public function registrations_scoped_via_payment(): void
+    {
+        $reg1 = $this->makeRegistrationFor($this->event1);
+        $this->makeRegistrationFor($this->event2);
+
+        $this->actingAs($this->panitiaA);
+
+        $this->assertSame([$reg1->id], Registration::forManagedEvents()->pluck('id')->all());
+    }
+
+    #[Test]
+    public function panitia_cannot_edit_foreign_event_via_direct_url(): void
+    {
+        // Global scope menyembunyikan event asing → binding gagal → 404
+        $this->actingAs($this->panitiaA)
+            ->get(route('admin.events.edit', $this->event2))
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function panitia_can_edit_own_event(): void
+    {
+        $this->actingAs($this->panitiaA)
+            ->get(route('admin.events.edit', $this->event1))
+            ->assertOk();
+    }
+
+    #[Test]
+    public function completed_event_is_read_only_for_panitia(): void
+    {
+        $this->event1->update(['status' => EventStatus::Completed]);
+
+        $this->actingAs($this->panitiaA);
+
+        $this->assertFalse($this->panitiaA->can('manage', $this->event1));
+        $this->get(route('admin.events.edit', $this->event1))->assertForbidden();
+
+        // Super-admin tetap bisa
+        $this->actingAs($this->superAdmin);
+        $this->assertTrue($this->superAdmin->can('manage', $this->event1));
+    }
+
+    #[Test]
+    public function panitia_sees_all_events_in_index_but_manage_button_scoped(): void
+    {
+        $this->actingAs($this->panitiaA)
+            ->get(route('admin.events.index'))
+            ->assertOk()
+            ->assertSee('Event Satu')
+            ->assertSee('Event Dua');
+
+        $this->assertTrue($this->panitiaA->can('manage', $this->event1));
+        $this->assertFalse($this->panitiaA->can('manage', $this->event2));
+    }
+
+    #[Test]
+    public function creating_event_auto_assigns_creator_as_panitia(): void
+    {
+        $this->actingAs($this->panitiaA)
+            ->post(route('admin.events.store'), [
+                'name' => 'Event Baru Panitia A',
+                'event_date' => now()->addMonth()->format('Y-m-d'),
+                'registration_deadline' => now()->addWeeks(2)->format('Y-m-d'),
+                'coach_fee' => 50000,
+                'event_fee' => 100000,
+                'status' => EventStatus::RegistrationOpen->value,
+            ]);
+
+        $event = Event::withoutGlobalScopes()->where('name', 'Event Baru Panitia A')->first();
+
+        $this->assertNotNull($event);
+        $this->assertTrue($event->panitia->contains($this->panitiaA));
+    }
+
+    #[Test]
+    public function super_admin_can_assign_panitia(): void
+    {
+        $this->actingAs($this->superAdmin)
+            ->put(route('admin.events.panitia.assign', $this->event1), [
+                'panitia_ids' => [$this->panitiaA->id, $this->panitiaB->id],
+            ])
+            ->assertRedirect();
+
+        $this->assertSame(
+            [$this->panitiaA->id, $this->panitiaB->id],
+            $this->event1->panitia()->pluck('user_id')->sort()->values()->all()
+        );
+    }
+
+    #[Test]
+    public function panitia_cannot_use_assign_endpoint(): void
+    {
+        $this->actingAs($this->panitiaA)
+            ->put(route('admin.events.panitia.assign', $this->event1), [
+                'panitia_ids' => [],
+            ])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function panitia_without_events_sees_empty_dashboard_state(): void
+    {
+        $lonely = User::factory()->create()->assignRole('panitia');
+
+        $this->actingAs($lonely)
+            ->get('/dashboard')
+            ->assertOk()
+            ->assertSee('Belum Ada Event yang Ditugaskan');
+    }
+
+    private function makePaymentFor(Event $event): Payment
+    {
+        return Payment::create([
+            'contingent_id' => Contingent::factory()->create()->id,
+            'event_id' => $event->id,
+            'total_amount' => 150000,
+            'status' => 'pending',
+        ]);
+    }
+
+    private function makeRegistrationFor(Event $event): Registration
+    {
+        $subCategory = SubCategory::factory()->create();
+
+        $participant = \App\Models\Participant::factory()->create([
+            'contingent_id' => Contingent::factory()->create()->id,
+        ]);
+
+        $payment = Payment::create([
+            'contingent_id' => $participant->contingent_id,
+            'event_id' => $event->id,
+            'total_amount' => 150000,
+            'status' => 'verified',
+        ]);
+
+        return Registration::create([
+            'participant_id' => $participant->id,
+            'payment_id' => $payment->id,
+            'sub_category_id' => $subCategory->id,
+            'status_berkas' => 'pending_review',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the event scoping epic (#133–#144) plus certificate template improvements:

### Event Scoping
- `event_user` pivot table — many-to-many panitia ↔ event assignments
- `ManagedEventScope` global scope: panitia only sees/manages assigned events; super-admin & kontingen unfiltered
- Payments, registrations, drafts scoped via `forManagedEvents()` in Livewire components, DocumentVerification, ReportController, DashboardController
- Completed events read-only for panitia
- Event creator auto-assigned as panitia
- `assign event panitia` permission (super-admin only) + visible assignments UI on event edit/show pages
- RolesAndPermissionsSeeder updated (idempotent — safe re-run)

### Certificates
- Split placeholders: `{kategori}` (Open/Festival), `{kelas}` (class), `{subkategori}` (sub category)
- Panitia-defined certificate number: free format + `{xxx}` sequential placeholder (e.g. `apr/7yh652/260829/{xxx}`)
- Number stored once in `registrations.certificate_no` — deterministic, never shifts on re-download
- Event detail page: CEK SERTIFIKAT in nav + hero buttons

## Tests
- `EventScopingTest` — 14 tests / 25 assertions ✅
- `Certificate` suite — 14 tests / 26 assertions ✅

Closes #133, closes #134, closes #135, closes #136, closes #137, closes #138, closes #139, closes #140, closes #141, closes #142, closes #143
Implements #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)